### PR TITLE
Constrain tests to the test/ directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "webpack-dev-server --mode development --open",
     "build": "webpack --mode production",
-    "test": "jest",
+    "test": "jest --rootDir test/",
     "lint": "eslint --cache --format codeframe --ext mjs,jsx,js src test"
   },
   "dependencies": {


### PR DESCRIPTION
The `yarn test` command is failing because is matching UI test files
that aren't ment to be tested programatically. This constrains the
tests to the test/ directory.