### PR TITLE
deploy: Deploy to a different bucket depending on branch

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -41,11 +41,15 @@ function uploadToS3(bucketName, keyPrefix, filePath) {
   });
 }
 
+const exec = require('child_process').execSync;
+const branch = exec('git rev-parse --abbrev-ref HEAD').toString().trim();
+const bucket = branch === 'stable' ? 'hack-web-stable' : 'hack-web';
+
 getFiles('build')
   .then((files) => {
     files.forEach((f) => {
       const prefix = path.dirname(path.relative('build', f));
-      uploadToS3('hack-web', prefix, f);
+      uploadToS3(bucket, prefix, f);
     });
   })
   .catch((e) => console.error(e));


### PR DESCRIPTION
To have dev and stable deployment it's needed to deploy to different S3
buckets. This patch check for the current branch and upload to the
stable bucket only if the branch is 'stable'.

https://phabricator.endlessm.com/T29605