### PR TITLE
toolbox: Side by side toolbox

### DIFF
--- a/apps/p5/index.js
+++ b/apps/p5/index.js
@@ -66,6 +66,13 @@ function reload() {
 <html>
   <head>
     <script src="p5.min.js"></script>
+    <style>
+      body {
+        padding: 0;
+        margin: 0;
+        text-align: center;
+      }
+    </style>
   </head>
   <body>
     <script>${globalParameters.code}</script>

--- a/src/ui/quest-fth-view.jsx
+++ b/src/ui/quest-fth-view.jsx
@@ -15,6 +15,7 @@ import {
 
 import PropTypes from 'prop-types';
 
+import SlideToHack from './slide-to-hack';
 import FlipToHack from './flip-to-hack';
 
 import HackIcon from './hack-icon.svg';
@@ -80,7 +81,7 @@ const useStyles = makeStyles((theme) => {
 
 
 const QuestFTHView = ({
-  toolbox, canvas, sidebar, controls, onFlipped,
+  toolbox, canvas, sidebar, controls, onFlipped, sideBySide,
 }) => {
   const classes = useStyles();
   const [open, setOpen] = React.useState(true);
@@ -105,11 +106,11 @@ const QuestFTHView = ({
         })}
       >
         {toolbox ? (
-          <FlipToHack
-            flipped={flipped}
-            toolbox={toolbox}
-            canvas={canvas}
-          />
+          <>
+            {sideBySide ? (
+              <SlideToHack flipped={flipped} toolbox={toolbox} canvas={canvas} />
+            ) : <FlipToHack flipped={flipped} toolbox={toolbox} canvas={canvas} />}
+          </>
         ) : <div className={classes.canvas}>{canvas}</div>}
         {toolbox && (
           <Fab
@@ -172,12 +173,14 @@ QuestFTHView.propTypes = {
   sidebar: PropTypes.element.isRequired,
   controls: PropTypes.element,
   onFlipped: PropTypes.func,
+  sideBySide: PropTypes.bool,
 };
 
 QuestFTHView.defaultProps = {
   onFlipped: null,
   toolbox: null,
   controls: null,
+  sideBySide: false,
 };
 
 export default QuestFTHView;

--- a/src/ui/slide-to-hack.jsx
+++ b/src/ui/slide-to-hack.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+
+import { Slide, Box, makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles({
+  root: {
+    position: 'relative',
+  },
+  toolbox: {
+    width: '50%',
+  },
+  toolboxWhenFlipped: {
+    width: '50%',
+  },
+  canvas: {
+    width: '100%',
+  },
+  canvasWhenFlipped: {
+    width: '50%',
+    position: 'absolute',
+    top: 0,
+    left: '50%',
+  },
+});
+
+const SlideToHack = ({ flipped, toolbox, canvas }) => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <Slide direction="right" in={flipped} mountOnEnter unmountOnExit>
+        <Box className={clsx(classes.toolbox, flipped && classes.toolboxWhenFlipped)}>
+          {toolbox}
+        </Box>
+      </Slide>
+      <div className={clsx(classes.canvas, flipped && classes.canvasWhenFlipped)}>
+        {canvas}
+      </div>
+    </div>
+  );
+};
+
+SlideToHack.propTypes = {
+  flipped: PropTypes.bool.isRequired,
+  toolbox: PropTypes.element.isRequired,
+  canvas: PropTypes.element.isRequired,
+};
+
+export default SlideToHack;

--- a/src/ui/test/p5.test.jsx
+++ b/src/ui/test/p5.test.jsx
@@ -83,6 +83,7 @@ const App = () => {
         toolbox={toolbox}
         canvas={canvas}
         sidebar={sidebar}
+        sideBySide
       />
     </TestWrapper>
   );

--- a/src/ui/toolbox/dynamic.jsx
+++ b/src/ui/toolbox/dynamic.jsx
@@ -70,6 +70,7 @@ ToolBoxGrid.propTypes = {
 
 const DynToolbox = ({
   toolbox,
+  width,
 }) => {
   const params = useSelector((state) => state.originalHackableApp);
   const dispatch = useDispatch();
@@ -81,7 +82,7 @@ const DynToolbox = ({
   return (
     <ThemeProvider theme={ToolboxTheme}>
       <Grid container spacing={0}>
-        <Grid item xs={8}>
+        <Grid item xs={width}>
           <ToolBoxGrid toolbox={toolbox} />
         </Grid>
         <Grid item xs={1}>
@@ -98,6 +99,11 @@ const DynToolbox = ({
 
 DynToolbox.propTypes = {
   toolbox: PropTypes.shape({ tabs: PropTypes.arrayOf(TabType) }).isRequired,
+  width: PropTypes.number,
+};
+
+DynToolbox.defaultProps = {
+  width: 8,
 };
 
 export default DynToolbox;

--- a/src/ui/toolbox/p5.jsx
+++ b/src/ui/toolbox/p5.jsx
@@ -40,7 +40,7 @@ const TOOLBOX = {
 };
 
 const Toolbox = () => (
-  <DynToolbox toolbox={TOOLBOX} />
+  <DynToolbox toolbox={TOOLBOX} width={11} />
 );
 
 export default Toolbox;


### PR DESCRIPTION
This patch adds a new property for the QuestFTHView to show the toolbox
on the back or side by side.

If sideBySide is set the new component SlideToHack is used instead of
the FlipToHack. This new component just shows the toolbox using the half
of the screen and moves the app to the right.

https://phabricator.endlessm.com/T29689