### PR TITLE
UI: Fix margins in messages

### DIFF
--- a/src/ui/chat-message.jsx
+++ b/src/ui/chat-message.jsx
@@ -47,6 +47,12 @@ const useStyles = makeStyles(({
       '& a': {
         color: palette.common.messageLink,
       },
+      '& p:first-child': {
+        marginBlockStart: 0,
+      },
+      '& p:last-child': {
+        marginBlockEnd: 0,
+      },
     },
     leftMessageBox: {
       textAlign: 'left',


### PR DESCRIPTION
In T29681 we added multiple `<p>` tags inside a message, and that
broke the styling.

https://phabricator.endlessm.com/T29681