### PR TITLE
CI: Put NPM cache in workspace

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+/.npm
 /build
 /node_modules

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,17 @@ pipeline {
             filename 'Dockerfile.build'
         }
     }
+
+    environment {
+        // This defaults to /.npm since $HOME is /, but that's not
+        // writable by the unprivileged jenkins user.
+        NPM_CONFIG_CACHE = "${env.WORKSPACE}/.npm"
+
+        // NPM can't be updated unprivileged, so silence the
+        // notification.
+        NPM_CONFIG_UPDATE_NOTIFIER = 'false'
+    }
+
     stages {
         stage('Build') {
             steps {


### PR DESCRIPTION
Inside the container $HOME is /, so the default NPM cache location is
/.npm. That's not writable by the unprivileged jenkins user and it would
be difficult to pre-create it in the container image since we don't know
the UID of the jenkins user beforehand. Instead, set the
NPM_CONFIG_CACHE environment variable to set the location of the cache
inside the workspace. While here, disable NPM update check notifications
since there's no way to do it as the unprivileged user, anyways.

https://phabricator.endlessm.com/T29701