### PR TITLE
Code: Fix AceEditor theme

### DIFF
--- a/src/ui/toolbox/panels/code.jsx
+++ b/src/ui/toolbox/panels/code.jsx
@@ -45,7 +45,7 @@ const CodePanel = ({
     <AceEditor
       width="100%"
       mode="javascript"
-      theme="terminal"
+      theme="monokai"
       value={text}
       onChange={build}
       name="editor"


### PR DESCRIPTION
The theme imported was changed to monokai but the theme in the Editor
was terminal. This patch changes the theme in the editor to be the same
imported.

https://phabricator.endlessm.com/T29852