### PR TITLE
QuestFTHView: Add option to hide the toolbox button

### DIFF
--- a/src/ui/quest-fth-view.jsx
+++ b/src/ui/quest-fth-view.jsx
@@ -184,7 +184,7 @@ const QuestFTHView = ({
             <div {...bind()} className={classes.canvas}>{canvas}</div>
           </>
         )}
-        {toolbox && (
+        {toolbox && !sideBySide && (
           <Fab
             color="secondary"
             aria-label="open toolbox"


### PR DESCRIPTION
This patch adds an option to hide the toolbox button and expose that
option to the sidetrack quest so this quest can show/hide depending on
the quest state.

By default is true, but we hide it for html and p5 quests.

https://phabricator.endlessm.com/T29868