### PR TITLE
UI: Update card selection behavior

### DIFF
--- a/src/ui/card-set-view.jsx
+++ b/src/ui/card-set-view.jsx
@@ -1,23 +1,25 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   Box,
+  ButtonBase,
   Container,
   Grid,
   makeStyles,
   Typography,
 } from '@material-ui/core';
 
+import { actions } from '../store';
 import ImageMainBg from './background.png';
 import SidePanel from './side-panel';
 import { getGoButton } from './main-button';
 import QuestFTHView from './quest-fth-view';
 import HackCard from './hack-card';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(({ spacing, zIndex }) => ({
   root: {
-    height: `calc(100% - ${theme.spacing(10)}px)`,
+    height: `calc(100% - ${spacing(10)}px)`,
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
@@ -26,12 +28,29 @@ const useStyles = makeStyles((theme) => ({
     backgroundRepeat: 'no-repeat',
     backgroundSize: 'cover',
   },
+  cardsContainer: {
+    pointerEvents: 'none',
+    zIndex: zIndex.drawer - 10,
+  },
+  backgroundButton: {
+    backgroundColor: 'transparent',
+    position: 'absolute',
+    top: 0,
+    width: '100%',
+    height: '100%',
+    zIndex: zIndex.drawer - 20,
+  },
 }));
 
 const CardSetView = ({ slug }) => {
   const classes = useStyles();
+  const dispatch = useDispatch();
   const cardset = useSelector((state) => state.cardsets.find((cs) => slug === cs.slug));
   const selectedCard = useSelector((state) => state.ui.cardSelected[slug]);
+
+  useEffect(() => {
+    dispatch(actions.sidePanelSetOpen());
+  }, [dispatch]);
 
   const getContent = (card) => (
     <Grid container justify="flex-start">
@@ -64,9 +83,15 @@ const CardSetView = ({ slug }) => {
     />
   );
 
+  const onBackgroundClick = () => {
+    if (selectedCard) {
+      dispatch(actions.deselectCards());
+    }
+  };
+
   const canvas = (
     <Box className={classes.root}>
-      <Container fixed maxWidth="md">
+      <Container fixed maxWidth="md" className={classes.cardsContainer}>
         <Grid container spacing={4}>
           {
             cardset.cards.map((c) => (
@@ -79,6 +104,7 @@ const CardSetView = ({ slug }) => {
           }
         </Grid>
       </Container>
+      <ButtonBase className={classes.backgroundButton} onClick={onBackgroundClick} />
     </Box>
   );
 
@@ -88,6 +114,7 @@ const CardSetView = ({ slug }) => {
       sidebar={sidebar}
       title={cardset.name}
       isMainPage={slug === '/home'}
+      disableHackButton
     />
   );
 };

--- a/src/ui/hack-card.jsx
+++ b/src/ui/hack-card.jsx
@@ -19,6 +19,7 @@ const defaultImage = '/assets/cards/default-card.svg';
 
 const useStyles = makeStyles(({ palette, spacing, transitions }) => ({
   root: {
+    pointerEvents: 'painted',
     width: `${spacing(28)}px`,
     height: `${spacing(42)}px`,
     display: 'flex',

--- a/src/ui/quest-fth-view.jsx
+++ b/src/ui/quest-fth-view.jsx
@@ -53,6 +53,9 @@ const useStyles = makeStyles((theme) => {
     dialogueToggleButtonClosed: {
       boxShadow: 'none',
     },
+    dialogueToggleButtonDisabled: {
+      opacity: 0.5,
+    },
     toolboxToggleButton: {
       position: 'absolute',
       top: `calc(50% - ${theme.spacing(2.5)}px)`,
@@ -110,6 +113,7 @@ const useStyles = makeStyles((theme) => {
 
 const QuestFTHView = ({
   toolbox, canvas, sidebar, controls, onFlipped, sideBySide, hideControls, title, isMainPage,
+  disableHackButton,
 }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
@@ -141,15 +145,6 @@ const QuestFTHView = ({
 
   const toggleOpen = () => {
     dispatch(actions.sidePanelToggleOpen());
-    if (open) {
-      setTimeout(() => {
-        dispatch(actions.deselectCards());
-      }, theme.transitions.duration.leavingScreen);
-    }
-  };
-
-  const onDrawerClose = () => {
-    dispatch(actions.deselectCards());
   };
 
   const toggleFlip = () => {
@@ -207,6 +202,7 @@ const QuestFTHView = ({
         elevation={6}
         className={clsx(classes.dialogueToggleButton, {
           [classes.dialogueToggleButtonClosed]: !open,
+          [classes.dialogueToggleButtonDisabled]: disableHackButton,
         })}
       >
         <Box m={1}>
@@ -216,6 +212,7 @@ const QuestFTHView = ({
             size="medium"
             onClick={toggleOpen}
             classes={{ root: classes.hackFabRoot }}
+            disabled={disableHackButton}
           >
             {open ? (
               <HackIconClose className={classes.hackIcon} />
@@ -233,7 +230,6 @@ const QuestFTHView = ({
         }}
         anchor="right"
         open={open}
-        onClose={onDrawerClose}
       >
         <Box
           display="flex"
@@ -258,6 +254,7 @@ QuestFTHView.propTypes = {
   hideControls: PropTypes.bool,
   title: PropTypes.string.isRequired,
   isMainPage: PropTypes.bool,
+  disableHackButton: PropTypes.bool,
 };
 
 QuestFTHView.defaultProps = {
@@ -267,6 +264,7 @@ QuestFTHView.defaultProps = {
   sideBySide: false,
   hideControls: true,
   isMainPage: false,
+  disableHackButton: false,
 };
 
 export default QuestFTHView;


### PR DESCRIPTION
- Have the empty state showing right from the beginning

- The FAB button is inaccessible like in the login page, so the drawer
  can not be closed.

- Clicking in the outside area of the cards (white bg) unselects a
  selected card and the empty state is displayed in the drawer.

https://phabricator.endlessm.com/T29891