### PR TITLE
sidetrack: remove timeout initialization

### DIFF
--- a/src/ui/test/sidetrack-quest.ink
+++ b/src/ui/test/sidetrack-quest.ink
@@ -1,8 +1,11 @@
 VAR flipped = 0
 VAR attractFTH = 0
 
+# The start level should be 0 by default, modifying this
+# will change the currentLevel
+# The starting level will be the highestAchievedLevel
+VAR startLevel = 0
 VAR currentLevel = 1
-VAR startLevel = 1
 VAR highestAchievedLevel = 1
 VAR availableLevels = 28
 


### PR DESCRIPTION
This patch changes how the sidetrack app is initialized improving how it
loads the iframe in the useEffect by avoiding non needed calls.

The useEffect to initialize the sidetrack app is called only once, using
`useRef(quest)` instead of the quest variable directly inside the
effect.

The game initialization is done now in the loadState, instead of do the
loadState and later update the startLevel. This changes a bit the
behavior of variables in the ink quest because the initial level will be
the highestAchievedLevel, and to change the level during the quest the
startLevel variable should be updated. The currentLevel is readOnly, so
modifying that in the quest won't change the level.

https://phabricator.endlessm.com/T29944