### PR TITLE
sidetrack: Fix level reloading

### DIFF
--- a/src/ui/test/sidetrack-quest.ink
+++ b/src/ui/test/sidetrack-quest.ink
@@ -28,8 +28,6 @@ VAR hasLockKey = 0
     ~ return "Hacker"
 
 === begin ===
-~ startLevel = 1
-~ highestAchievedLevel = 1
 -> level1_1
 
 === level1_1 ===

--- a/src/ui/test/sidetrack-quest.test.jsx
+++ b/src/ui/test/sidetrack-quest.test.jsx
@@ -134,7 +134,8 @@ const SidetrackQuest = () => {
       const state = { ...params, ...code };
       dispatch(actions.hackableAppSet(state));
       if (firstTime) {
-        dispatch(actions.originalHackableAppSet(state));
+        const initialState = { ...state, startLevel: state.highestAchievedLevel };
+        dispatch(actions.originalHackableAppSet(initialState));
       } else {
         updateQuestVariables(params);
       }
@@ -291,9 +292,20 @@ const SidetrackQuest = () => {
     />
   );
 
+  const restartApp = () => {
+    const { originalHackableApp } = store.getState();
+    const { startLevel, highestAchievedLevel } = originalHackableApp;
+    const app = appRef.current.contentWindow;
+
+    app.globalParameters.highestAchievedLevel = highestAchievedLevel;
+    const level = app[`globalLevel${startLevel}Parameters`];
+    app.game.scene.start('Game', level);
+  };
+
   const onRestartSelected = () => {
-    // TODO: Bring the app and toolbox to the initial state.
     restartQuest();
+    restartApp();
+    focusApp();
   };
 
   const onFlipped = (f) => {


### PR DESCRIPTION
The app restart cannot be done just modifying the startLevel variable
because the sidetrack app just check for changes and the startLevel
doesn't change if we don't change by hand, so we need to enforce the
scene reload.

This will fix the problem of the first level twice because it was setted
by the quest variable modification callback that is called when the
dialog changes and for the first time it was getting the first
startLevel assignement.

https://phabricator.endlessm.com/T29987