### PR TITLE
UI: Size cards according to breakpoints

### DIFF
--- a/src/ui/card-set-view.jsx
+++ b/src/ui/card-set-view.jsx
@@ -17,7 +17,9 @@ import { GoButton } from './main-button';
 import QuestFTHView from './quest-fth-view';
 import HackCard from './hack-card';
 
-const useStyles = makeStyles(({ spacing, zIndex }) => ({
+const useStyles = makeStyles(({
+  breakpoints, custom, spacing, zIndex,
+}) => ({
   root: {
     height: `calc(100% - ${spacing(10)}px)`,
     display: 'flex',
@@ -30,7 +32,16 @@ const useStyles = makeStyles(({ spacing, zIndex }) => ({
   },
   cardsContainer: {
     pointerEvents: 'none',
-    zIndex: zIndex.drawer - 10,
+    zIndex: zIndex.appBar - 10,
+    [breakpoints.down('md')]: {
+      maxWidth: custom.cardSizes.downMd.containerWidth,
+    },
+    [breakpoints.only('lg')]: {
+      maxWidth: custom.cardSizes.onlyLg.containerWidth,
+    },
+    [breakpoints.only('xl')]: {
+      maxWidth: custom.cardSizes.onlyXl.containerWidth,
+    },
   },
   backgroundButton: {
     backgroundColor: 'transparent',
@@ -38,7 +49,7 @@ const useStyles = makeStyles(({ spacing, zIndex }) => ({
     top: 0,
     width: '100%',
     height: '100%',
-    zIndex: zIndex.drawer - 20,
+    zIndex: zIndex.appBar - 20,
   },
 }));
 
@@ -94,14 +105,12 @@ const CardSetView = ({ slug }) => {
 
   const canvas = (
     <Box className={classes.root}>
-      <Container fixed maxWidth="md" className={classes.cardsContainer}>
+      <Container fixed className={classes.cardsContainer}>
         <Grid container spacing={4}>
           {
             cardset.cards.map((c) => (
-              <Grid key={c.slug} item xs={4}>
-                <Container>
-                  <HackCard cardset={cardset} card={c} />
-                </Container>
+              <Grid key={c.slug} item xs={12} md={4}>
+                <HackCard cardset={cardset} card={c} />
               </Grid>
             ))
           }

--- a/src/ui/hack-card.jsx
+++ b/src/ui/hack-card.jsx
@@ -17,14 +17,26 @@ import { GoButton } from './main-button';
 
 const defaultImage = '/assets/cards/default-card.png';
 
-const useStyles = makeStyles(({ palette, spacing, transitions }) => ({
+const useStyles = makeStyles(({
+  breakpoints, custom, palette, spacing, transitions,
+}) => ({
   root: {
     pointerEvents: 'painted',
-    width: `${spacing(28)}px`,
-    height: `${spacing(42)}px`,
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    [breakpoints.down('md')]: {
+      width: custom.cardSizes.downMd.width,
+      height: custom.cardSizes.downMd.height,
+    },
+    [breakpoints.only('lg')]: {
+      width: custom.cardSizes.onlyLg.width,
+      height: custom.cardSizes.onlyLg.height,
+    },
+    [breakpoints.only('xl')]: {
+      width: custom.cardSizes.onlyXl.width,
+      height: custom.cardSizes.onlyXl.height,
+    },
     display: 'flex',
-    backgroundSize: 'cover',
-    backgroundPosition: 'center top',
     flexDirection: 'column',
     justifyContent: 'flex-end',
     position: 'relative',
@@ -40,6 +52,8 @@ const useStyles = makeStyles(({ palette, spacing, transitions }) => ({
     boxShadow: `0px 0px 0px ${spacing(1)}px ${palette.primary.main}`,
   },
   backgroundBox: {
+    backgroundSize: 'cover',
+    backgroundPosition: 'center top',
     backgroundImage: ({ card }) => {
       const bgImg = `url('/assets/cards/${card.slug.slice(1)}/card.png')`;
       return `${bgImg}, url('${defaultImage}')`;
@@ -53,13 +67,20 @@ const useStyles = makeStyles(({ palette, spacing, transitions }) => ({
     borderTop: `${spacing(1)}px solid ${palette.primary.main}`,
     backgroundColor: palette.background.paper,
     zIndex: 1,
+    [breakpoints.down('lg')]: {
+      padding: `${spacing(0.5)}px`,
+      '& .MuiTypography-gutterBottom': {
+        marginBottom: 0,
+      },
+    },
   },
   cardActions: {
     display: 'flex',
     justifyContent: 'center',
-    paddingBottom: 0,
-    paddingLeft: 0,
-    paddingRight: 0,
+    paddingBottom: spacing(1),
+    [breakpoints.down('md')]: {
+      padding: `0 0 ${spacing(1)}px 0`,
+    },
   },
   collapsableBox: {
     display: 'flex',
@@ -69,7 +90,20 @@ const useStyles = makeStyles(({ palette, spacing, transitions }) => ({
     overflow: 'hidden',
   },
   collapsableBoxSelected: {
-    maxHeight: `${spacing(15.5)}px`,
+    [breakpoints.down('md')]: {
+      maxHeight: custom.cardSizes.downMd.height,
+    },
+    [breakpoints.only('lg')]: {
+      maxHeight: custom.cardSizes.onlyLg.height,
+    },
+    [breakpoints.only('xl')]: {
+      maxHeight: custom.cardSizes.onlyXl.height,
+    },
+  },
+  cardSubtitle: {
+    [breakpoints.down('md')]: {
+      display: 'none',
+    },
   },
   actions: {
     justifyContent: 'flex-end',
@@ -110,7 +144,7 @@ const HackCard = ({ card, cardset }) => {
             isSelected && classes.collapsableBoxSelected,
           )}
           >
-            <Typography variant="body2" color="textSecondary">
+            <Typography variant="body2" color="textSecondary" className={classes.cardSubtitle}>
               { card.subtitle }
             </Typography>
             <CardActions className={classes.cardActions}>

--- a/src/ui/theme.jsx
+++ b/src/ui/theme.jsx
@@ -43,6 +43,23 @@ const theme = createMuiTheme({
     // Fill 3 of 12 columns in XL screen size:
     drawerWidth: defaultTheme.breakpoints.values.xl * 0.25,
     appBarHeight: defaultTheme.spacing(10),
+    cardSizes: {
+      downMd: {
+        width: defaultTheme.spacing(14),
+        height: defaultTheme.spacing(21),
+        containerWidth: defaultTheme.spacing(14) * 3 + defaultTheme.spacing(8) * 2,
+      },
+      onlyLg: {
+        width: defaultTheme.spacing(18.5),
+        height: defaultTheme.spacing(28),
+        containerWidth: defaultTheme.spacing(18.5) * 3 + defaultTheme.spacing(8) * 2,
+      },
+      onlyXl: {
+        width: defaultTheme.spacing(28),
+        height: defaultTheme.spacing(42),
+        containerWidth: defaultTheme.spacing(28) * 3 + defaultTheme.spacing(8) * 2,
+      },
+    },
   },
 });
 


### PR DESCRIPTION
Conditionally size the cards using the breakpoints. We have 3 sets:

- Medium and below (small, extra-small)
- Large
- Extra-large

Also:

- Place cards below app bar.
- Don't show the card subtitle in the smaller cards ("below large" set)
- Remove extra container from cards.
- Make cards background cover correctly.
- Gracefully degrade extra-small grid to one card per row.

https://phabricator.endlessm.com/T29964