### PR TITLE
UI: Fix some react errors

### DIFF
--- a/src/ui/dialogue.jsx
+++ b/src/ui/dialogue.jsx
@@ -143,7 +143,7 @@ const Dialogue = ({
     </>
   );
 
-  const buttons = hasEnded ? endChoices : choices.map((choice) => getChoiceButton(choice));
+  const buttons = hasEnded ? endChoices : <>{choices.map((choice) => getChoiceButton(choice))}</>;
 
   return <SidePanel content={content} buttons={buttons} card={card} />;
 };

--- a/src/ui/fth-button/index.jsx
+++ b/src/ui/fth-button/index.jsx
@@ -92,7 +92,10 @@ const FTHButton = ({
         className={clsx(className, classes.fthButton, {
           [classes.fthButtonFlipped]: flipped,
         })}
-      />
+      >
+        {/* Fab requires one child */}
+        <></>
+      </Fab>
     </>
   );
 };

--- a/src/ui/test/html-quest.test.jsx
+++ b/src/ui/test/html-quest.test.jsx
@@ -93,7 +93,7 @@ const HtmlQuest = () => {
       title="HTML sandbox"
       className={classes.frame}
       src="/apps/html/index.html"
-      sandbox
+      sandbox="allow-same-origin allow-scripts"
     />
   );
 

--- a/src/ui/test/p5-quest.test.jsx
+++ b/src/ui/test/p5-quest.test.jsx
@@ -86,7 +86,7 @@ const P5Quest = () => {
       title="P5.js sandbox"
       className={classes.frame}
       src="/apps/p5/index.html"
-      sandbox
+      sandbox="allow-same-origin allow-scripts"
     />
   );
 

--- a/src/ui/test/sidetrack-quest.test.jsx
+++ b/src/ui/test/sidetrack-quest.test.jsx
@@ -291,6 +291,7 @@ const SidetrackQuest = () => {
       title="Fizzics App"
       className={classes.frame}
       src="/apps/hack-toy-apps/com.hack_computer.Sidetrack/app/index.html"
+      sandbox="allow-same-origin allow-scripts"
     />
   );
 

--- a/src/ui/toolbox/lockscreen.jsx
+++ b/src/ui/toolbox/lockscreen.jsx
@@ -71,7 +71,7 @@ const LockScreen = ({
       <video
         ref={video}
         className={clsx(classes.base, classes.video)}
-        preload
+        preload="auto"
         onPlay={hideButton}
         onEnded={onUnlock}
       >


### PR DESCRIPTION
This patch fixes some errors that appears on the browser console when
using the app.

 * iframe: Use sandbox with a specific string instead of as boolean
 * preload="auto" for lockscreen video
 * Add required child to FtH Button Fab
 * Dialogue choices can't be an array, it should be an object

https://phabricator.endlessm.com/T29998