### PR TITLE
Web quest: Add doctype declaration

### DIFF
--- a/apps/html/index.js
+++ b/apps/html/index.js
@@ -1,5 +1,5 @@
 var globalParameters = {
-  code: `
+  code: `<!DOCTYPE html>
 <html>
    <head>
       <title>This is a Test Web Page!</title>
@@ -9,7 +9,7 @@ var globalParameters = {
       <p>Hello, world!</p>
    </body>
 </html>
-  `,
+`,
 };
 
 function reload() {


### PR DESCRIPTION
All HTML documents must start with that declaration.

Also, remove two trailing spaces from the end.