### PR TITLE
deploy: Different bucket depending on HOME

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "repository": "https://github.com/endlessm/hack-web.git",
   "author": "Endless Mobile, Inc.",
   "license": "UNLICENSED",
-  "domain": "hack-web.s3-website.us-east-2.amazonaws.com",
   "private": true,
   "scripts": {
     "start": "webpack-dev-server --mode development --open",

--- a/src/cognito.jsx
+++ b/src/cognito.jsx
@@ -6,10 +6,8 @@ import {
   CookieStorage,
 } from 'amazon-cognito-identity-js';
 
-import config from '../package.json';
-
 let CookieStorageClass = CookieStorage;
-let COOKIE_DOMAIN = config.domain;
+let COOKIE_DOMAIN = '.hack-computer.com';
 
 if (process.env.NODE_ENV === 'development') {
   COOKIE_DOMAIN = null;

--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -41,9 +41,8 @@ function uploadToS3(bucketName, keyPrefix, filePath) {
   });
 }
 
-const exec = require('child_process').execSync;
-const branch = exec('git rev-parse --abbrev-ref HEAD').toString().trim();
-const bucket = branch === 'stable' ? 'hack-web-stable' : 'hack-web';
+const branch = path.basename(process.env.HOME).split('-').slice(-1).pop();
+const bucket = branch === 'stable' ? 'try.hack-computer.com' : 'dev.hack-computer.com';
 
 getFiles('build')
   .then((files) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ const plugin = new webpack.DefinePlugin({
   CONFIG: {
     mode: JSON.stringify(module.exports.mode),
     testAuth: process.env.TEST_AUTH,
+    branch: JSON.stringify(process.env.HOME.split('-').slice(-1).pop()),
   },
 });
 module.exports.plugins.push(plugin);


### PR DESCRIPTION
The deployment using the jenkins job is unable to get the git branch
name because how the checkout is done so we shouldn't use that to get
the branch name.

This patch uses the HOME variable instead that is hack-web-master or
hack-web-stable during the CI process. It will deploy to
dev.hack-computer.com or try.hack-computer.com AWS S3 bucket depending
on that so we don't need commits in stable that are not in master.

https://phabricator.endlessm.com/T30017