### PR TITLE
ui: Move FtH button inside the FlipToHack component

### DIFF
--- a/src/ui/flip-to-hack.jsx
+++ b/src/ui/flip-to-hack.jsx
@@ -1,9 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import clsx from 'clsx';
 import { fade, makeStyles } from '@material-ui/core';
 import PropTypes from 'prop-types';
 
+import FTHButton from './fth-button';
+
 const useStyles = makeStyles((theme) => ({
+  toolboxToggleButton: {
+    position: 'fixed',
+    top: `calc(50% - ${theme.custom.fthButton.height}px)`,
+    left: 0,
+    zIndex: theme.zIndex.drawer + 20,
+    transition: `opacity ${theme.transitions.duration.complex / 2}ms`,
+    transitionTimingFunction: 'steps(1, end)',
+  },
+  buttonFlipped: {
+    opacity: 0,
+  },
   flipBox: {
     zIndex: 0,
     perspective: `${theme.custom.flipToHackPerspective}px`,
@@ -49,17 +62,38 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 
-const FlipToHack = ({ flipped, toolbox, canvas }) => {
+const FlipToHack = ({
+  toolbox, canvas, attractFTH, onFlipped,
+}) => {
   const classes = useStyles();
+  const [flipped, setFlipped] = useState(false);
+
+  const toggleFlip = () => {
+    setFlipped(!flipped);
+    if (onFlipped) {
+      onFlipped(!flipped);
+    }
+  };
 
   return (
     <div className={classes.flipBox}>
       <div className={clsx(classes.flipBoxInner, flipped && classes.flipBoxInnerWhenFlipped)}>
         <div className={clsx(classes.canvas, flipped && classes.canvasWhenFlipped)}>
           {canvas}
+          <FTHButton
+            onClick={toggleFlip}
+            className={clsx(classes.toolboxToggleButton, flipped && classes.buttonFlipped)}
+            attracting={attractFTH}
+          />
         </div>
         <div className={clsx(classes.toolbox, flipped && classes.toolboxWhenFlipped)}>
           {toolbox}
+          <FTHButton
+            onClick={toggleFlip}
+            className={classes.toolboxToggleButton}
+            flipped
+            attracting={attractFTH}
+          />
         </div>
       </div>
     </div>
@@ -67,9 +101,15 @@ const FlipToHack = ({ flipped, toolbox, canvas }) => {
 };
 
 FlipToHack.propTypes = {
-  flipped: PropTypes.bool.isRequired,
   toolbox: PropTypes.element.isRequired,
   canvas: PropTypes.element.isRequired,
+  attractFTH: PropTypes.bool,
+  onFlipped: PropTypes.func,
+};
+
+FlipToHack.defaultProps = {
+  attractFTH: false,
+  onFlipped: null,
 };
 
 export default FlipToHack;

--- a/src/ui/fth-button/index.jsx
+++ b/src/ui/fth-button/index.jsx
@@ -13,13 +13,13 @@ import flipBackHover from './flip-back-hover.png';
 import flipFrontDimmed from './flip-front-dimmed.png';
 import flipBackDimmed from './flip-back-dimmed.png';
 
-const useStyles = makeStyles(({ transitions }) => ({
+const useStyles = makeStyles(({ custom, transitions }) => ({
   fthButton: {
     // Note, the following sizes are intentionally hardcoded to fit
     // the assets.
     borderRadius: '0 60px 60px 0',
-    width: '66px',
-    height: '124px',
+    width: custom.fthButton.width,
+    height: custom.fthButton.height,
     boxShadow: 'none',
     transition: transitions.create(['background-image'], {
       easing: transitions.easing.easeInOut,
@@ -50,7 +50,7 @@ const useStyles = makeStyles(({ transitions }) => ({
     // the assets.
     width: '0px',
     height: '0px',
-    marginTop: 124 / 2,
+    marginTop: custom.fthButton.height / 2,
     animation: '$glow 1s alternate infinite',
   },
 

--- a/src/ui/quest-fth-view.jsx
+++ b/src/ui/quest-fth-view.jsx
@@ -20,7 +20,6 @@ import { actions } from '../store';
 import HackTopBar from './hack-top-bar';
 import SlideToHack from './slide-to-hack';
 import FlipToHack from './flip-to-hack';
-import FTHButton from './fth-button';
 
 import HackIconOpen from './hack-icon-open.svg';
 import HackIconClose from './hack-icon-close.svg';
@@ -52,10 +51,6 @@ const useStyles = makeStyles((theme) => {
     },
     dialogueToggleButtonDisabled: {
       opacity: 0.5,
-    },
-    toolboxToggleButton: {
-      position: 'absolute',
-      top: `calc(50% - ${theme.spacing(2.5)}px)`,
     },
     controlsContainer: {
       position: 'absolute',
@@ -150,9 +145,6 @@ const QuestFTHView = ({
 
   const open = useSelector((state) => state.ui.sidePanelOpen);
 
-  // When sideBySide is true we show the toolbox by default
-  const [flipped, setFlipped] = useState(sideBySide);
-
   const [movingTimeout, setMovingTimeout] = useState();
   const [controlsVisible, setControlsVisible] = useState(!hideControls);
 
@@ -177,13 +169,6 @@ const QuestFTHView = ({
     dispatch(actions.sidePanelToggleOpen());
   };
 
-  const toggleFlip = () => {
-    setFlipped(!flipped);
-    if (onFlipped) {
-      onFlipped(!flipped);
-    }
-  };
-
   const canvasWrap = (
     <>
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
@@ -202,22 +187,21 @@ const QuestFTHView = ({
         {toolbox ? (
           <>
             {sideBySide ? (
-              <SlideToHack flipped={flipped} toolbox={toolbox} canvas={canvasWrap} />
-            ) : <FlipToHack flipped={flipped} toolbox={toolbox} canvas={canvasWrap} />}
+              <SlideToHack flipped toolbox={toolbox} canvas={canvasWrap} />
+            ) : (
+              <FlipToHack
+                toolbox={toolbox}
+                canvas={canvasWrap}
+                attractFTH={attractFTH}
+                onFlipped={onFlipped}
+              />
+            )}
           </>
         ) : (
           <>
             {/* eslint-disable-next-line react/jsx-props-no-spreading */}
             <div {...bind()} className={classes.canvas}>{canvas}</div>
           </>
-        )}
-        {toolbox && !sideBySide && (
-          <FTHButton
-            onClick={toggleFlip}
-            className={classes.toolboxToggleButton}
-            flipped={flipped}
-            attracting={attractFTH}
-          />
         )}
         {controls && (
           <Box className={clsx(classes.controlsContainer, {

--- a/src/ui/test/flip-to-hack.test.jsx
+++ b/src/ui/test/flip-to-hack.test.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {
   Container,
   Box,
-  Button,
   Typography,
 } from '@material-ui/core';
 
@@ -11,12 +10,6 @@ import TestWrapper from './test-wrapper';
 import FlipToHack from '../flip-to-hack';
 
 const App = () => {
-  const [flipped, setFlipped] = React.useState(false);
-
-  const toggleFlip = () => {
-    setFlipped(!flipped);
-  };
-
   const width = 400;
   const height = 300;
 
@@ -39,9 +32,7 @@ const App = () => {
           Flip to Hack!
         </Typography>
         <Box style={{ width, height }}>
-          <Button onClick={toggleFlip}>Flip</Button>
           <FlipToHack
-            flipped={flipped}
             toolbox={toolbox}
             canvas={canvas}
           />

--- a/src/ui/theme.jsx
+++ b/src/ui/theme.jsx
@@ -37,6 +37,10 @@ const theme = createMuiTheme({
     borderRadius: 16,
   },
   custom: {
+    fthButton: {
+      width: 66,
+      height: 124,
+    },
     flipToHackPerspective: 1000,
     landingTitleGradientDirection: 270,
     chatMessageMaxWidth: '90%',


### PR DESCRIPTION
This patch moves the button from the QuestFTHView to the FlipToHack
component and instead of one button we've two, one for the canvas and
one for the toolbox so we can see the button rotate with on flip.

https://phabricator.endlessm.com/T29954