### PR TITLE
toolbox: Fix sidetrack code error in chrome

### DIFF
--- a/src/ui/toolbox/sidetrack.jsx
+++ b/src/ui/toolbox/sidetrack.jsx
@@ -157,6 +157,7 @@ const validateLevel = (code) => {
 
 // This function is copied from the repo hack-toy-apps, file src/codeview.js
 const getErrorLine = (exception) => {
+  window.err = exception;
   const stackFrames = exception.stack.split('\n');
   // The format of stack frames originating inside a function created with
   // new Function(...) looks like this:
@@ -168,7 +169,13 @@ const getErrorLine = (exception) => {
   // in the next 3 lines where the error actually is. For more details,
   // see https://phabricator.endlessm.com/T29104#793998
 
-  const userScriptStackFrame = stackFrames.find((line) => (/ > Function:/).test(line));
+  // Firefox: > Function:row:column
+  // Chrome: <anonymous>:row:column
+  const userScriptStackFrame = stackFrames.find((line) => (/ (> Function|<anonymous>):/).test(line));
+  if (!userScriptStackFrame) {
+    return [0, 0];
+  }
+
   const [line, column] = userScriptStackFrame.split(':').slice(-2);
   return [Math.max(0, line - fixedDelta), column ? column - 1 : 0];
 };


### PR DESCRIPTION
The way to detect the line and column of an error in chrome is different
so we need to update the regular expression.

This patch also makes this code more robust because in case that a line
is not found the error will be shown at the top, but won't crash.

https://phabricator.endlessm.com/T30031