### PR TITLE
Add browser support check

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@material-ui/lab": "^4.0.0-alpha.43",
     "ace-builds": "^1.4.8",
     "amazon-cognito-identity-js": "^3.2.4",
+    "browser-update": "^3.3.16",
     "clsx": "^1.1.0",
     "inkjs": "^1.10.3",
     "prop-types": "^15",

--- a/src/ui/app.jsx
+++ b/src/ui/app.jsx
@@ -10,6 +10,7 @@ import { useSelector } from 'react-redux';
 import 'typeface-roboto';
 import ReactGA from 'react-ga';
 import PropTypes from 'prop-types';
+import browserUpdate from 'browser-update';
 
 import './app.css';
 import theme from './theme';
@@ -22,6 +23,21 @@ import { P5Quest } from './test/p5-quest.test';
 import { HtmlQuest } from './test/html-quest.test';
 import { PdfQuest } from './test/pdf-quest.test';
 import { SidetrackQuest } from './test/sidetrack-quest.test';
+
+browserUpdate({
+  required: {
+    // From Material-UI, support Firefox >= 52
+    f: 52,
+    // From Material-UI, support Chrome >= 49
+    c: 49,
+    // From Material-UI, support IE/Edge >= 14
+    i: 14,
+    // From Material-UI, support Safari >= 10
+    s: 10,
+    // No Opera specified in Material-UI, so we guess the last 4 releases:
+    o: -4,
+  },
+});
 
 ReactGA.initialize('UA-160877903-1');
 const GAWrapper = ({ children }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,6 +2264,11 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
+browser-update@^3.3.16:
+  version "3.3.16"
+  resolved "https://registry.yarnpkg.com/browser-update/-/browser-update-3.3.16.tgz#1d30c3700944a6b6f6635bec2a17fd53511a4d37"
+  integrity sha512-K1sqiCHwZXXQEatNE+BAn9UbVfgh/hdmD+56qUOy+eUoW1oo+b+d5dlc9CPpfgL03EZX5d7VXzJxUGkAfil3LA==
+
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"


### PR DESCRIPTION
This commit adds the browser-update npm library as dependency, so a
yarn install is needed to update the dependencies.

The browserUpdate check is called in the main, with the parameters
specified by Material-UI here:
https://material-ui.com/getting-started/supported-platforms/#browser

https://phabricator.endlessm.com/T29978