### PR TITLE
toolbox: Fix code editor build annotations

### DIFF
--- a/src/ui/toolbox/panels/code.jsx
+++ b/src/ui/toolbox/panels/code.jsx
@@ -66,8 +66,7 @@ const CodePanel = ({
 
   const [annotations, setAnnotations] = useState([]);
 
-  let timeout = null;
-  const delayBuild = (c) => {
+  const build = (c) => {
     const result = compile(c, params);
 
     if (result) {
@@ -77,26 +76,6 @@ const CodePanel = ({
       setAnnotations(result.annotations || []);
     }
   };
-
-  const build = (c) => {
-    if (!buildDelay) {
-      delayBuild(c);
-      return;
-    }
-
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-
-    timeout = setTimeout(() => delayBuild(c), buildDelay);
-  };
-
-  useEffect(() => {
-    const result = compile(text, params);
-    if (result && result.annotations) {
-      setAnnotations(result.annotations);
-    }
-  }, [text, compile, params]);
 
   const theme = useTheme();
   const editorHeight = fullHeight ? `${size.height - theme.spacing(10)}px` : undefined;
@@ -112,6 +91,7 @@ const CodePanel = ({
       theme="monokai"
       value={text}
       onChange={build}
+      debounceChangePeriod={buildDelay}
       name="editor"
       editorProps={{ $blockScrolling: true }}
       annotations={annotations}

--- a/src/ui/toolbox/sidetrack.jsx
+++ b/src/ui/toolbox/sidetrack.jsx
@@ -188,6 +188,7 @@ function instructionCode(_p, code) {
   return code;
 }
 
+let lastAnnotationId = 0;
 function compileCode(p, code) {
   const annotations = [];
 
@@ -200,11 +201,16 @@ function compileCode(p, code) {
     validateFunction(code);
   } catch (e) {
     const [row, column] = getErrorLine(e);
+    lastAnnotationId += 1;
     annotations.push({
       type: 'error',
       text: e.message,
       row,
       column,
+      // Unique id to make each compilation annotation object different, to
+      // ensure that the annotations are updated and the code editor is
+      // rendered.
+      id: lastAnnotationId,
     });
   }
 


### PR DESCRIPTION
The custom annotations in the code editor was not working correctly
because it's a state property and if the annotation is setted with the
same object, the component doesn't trigger the render and the
annotations dissapears.

This patch fix the problem with custom annotations for sidetrack just
adding a random id to each annotation created so we can ensure that is
different from the previous one.

This patch also improves the build method using the debounceChangePeriod
property from AceEditor instead of a custom timeout.

https://phabricator.endlessm.com/T30044