### PR TITLE
toolbox: Priorize custom annotations over worker

### DIFF
--- a/src/ui/toolbox/sidetrack.jsx
+++ b/src/ui/toolbox/sidetrack.jsx
@@ -188,7 +188,7 @@ function instructionCode(_p, code) {
   return code;
 }
 
-let lastAnnotationId = 0;
+let lastAnnotationId = 1;
 function compileCode(p, code) {
   const annotations = [];
 


### PR DESCRIPTION
There's a bug in the AceEditor when combining custom annotations with
worker:
https://github.com/securingsincity/react-ace/issues/483

This patch tries to mitigate this problem with a custom method linked to
the onValidate signal that checks if the custom annotaions are part of
the editor annotations and adding them if they are not present.

https://phabricator.endlessm.com/T30063