### PR TITLE
Toolbox: reset app state on quest component umount

### DIFF
--- a/src/store.jsx
+++ b/src/store.jsx
@@ -34,6 +34,9 @@ const actions = {
     type: 'SET-PARAM',
     payload: { key, value },
   }),
+  resetHackableApp: () => ({
+    type: 'RESET',
+  }),
 };
 
 function authReducer(state = {}, action) {
@@ -91,6 +94,9 @@ function originalHackableAppReducer(state = {}, action) {
     case 'ORIG-SET': {
       return { ...action.payload };
     }
+    case 'RESET': {
+      return {};
+    }
     default:
       return state;
   }
@@ -104,6 +110,9 @@ function hackableAppReducer(state = {}, action) {
     case 'SET-PARAM': {
       const { key, value } = action.payload;
       return { ...state, [key]: value };
+    }
+    case 'RESET': {
+      return {};
     }
     default:
       return state;

--- a/src/ui/test/html-quest.test.jsx
+++ b/src/ui/test/html-quest.test.jsx
@@ -1,5 +1,5 @@
 import { hot } from 'react-hot-loader';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import {
@@ -37,19 +37,16 @@ const HtmlQuest = () => {
   const dispatch = useDispatch();
   const card = useCard();
 
-  const [firstTimeCode, setFirstTimeCode] = useState(true);
-
   const {
     quest, dialogue, choices, setCurrentChoice, hasEnded, restartQuest,
   } = useQuest(questContent);
 
   useEffect(() => {
     const changeCallback = (params, firstTime = false) => {
-      if (firstTime && firstTimeCode) {
+      if (firstTime) {
         // only update the toolbox code editor the first time
         dispatch(actions.hackableAppSet(params));
         dispatch(actions.originalHackableAppSet(params));
-        setFirstTimeCode(false);
       }
     };
 
@@ -67,8 +64,14 @@ const HtmlQuest = () => {
         }
       });
     };
-    return store.subscribe(handleChange);
-  }, [firstTimeCode, dispatch, quest, setCurrentChoice]);
+
+    const unsubscribe = store.subscribe(handleChange);
+    return () => {
+      unsubscribe();
+      // Reset hackableApp state on umount
+      dispatch(actions.resetHackableApp());
+    };
+  }, [dispatch, quest, setCurrentChoice]);
 
   const toolbox = <Toolbox />;
 

--- a/src/ui/test/sidetrack-quest.test.jsx
+++ b/src/ui/test/sidetrack-quest.test.jsx
@@ -286,7 +286,12 @@ const SidetrackQuest = () => {
 
     focusApp();
 
-    return store.subscribe(handleChange);
+    const unsubscribe = store.subscribe(handleChange);
+    return () => {
+      unsubscribe();
+      // Reset hackableApp state on umount
+      dispatch(actions.resetHackableApp());
+    };
   }, [dispatch, setCurrentChoice]);
 
   // Update the app when the quest changes some variable


### PR DESCRIPTION
The proxy for the app should be done just one time for each app quest
and should reset the state on umount. This will prevent collision
between quest apps because they use the same store state hackableApp.

https://phabricator.endlessm.com/T30067