### PR TITLE
sidetrack: Only update toolbox state on level change

### DIFF
--- a/src/ui/test/sidetrack-quest.test.jsx
+++ b/src/ui/test/sidetrack-quest.test.jsx
@@ -146,6 +146,11 @@ const SidetrackQuest = () => {
         return;
       }
 
+      // update toolbox state only if level changes
+      if (params.currentLevel === store.getState().hackableApp.currentLevel) {
+        return;
+      }
+
       const level = app.contentWindow[`globalLevel${params.currentLevel}Parameters`];
 
       if (questRef.current) {


### PR DESCRIPTION
Updating the toolbox state with every app change introduces a problem in
the code editor that shows the previous state if the user types just
between an update process.

We don't need to refresh the toolbox state with every change, we only
need to update the state when the level changes.

https://phabricator.endlessm.com/T30064