### PR TITLE
Revert "sidetrack: Only update toolbox state on level change"

### DIFF
--- a/src/ui/test/sidetrack-quest.test.jsx
+++ b/src/ui/test/sidetrack-quest.test.jsx
@@ -146,11 +146,6 @@ const SidetrackQuest = () => {
         return;
       }
 
-      // update toolbox state only if level changes
-      if (params.currentLevel === store.getState().hackableApp.currentLevel) {
-        return;
-      }
-
       const level = app.contentWindow[`globalLevel${params.currentLevel}Parameters`];
 
       if (questRef.current) {


### PR DESCRIPTION
This reverts commit fe04da40aff8d298dd491df308d0468a3e6bd57e.

The app/quest update process is more complex so we can't just don't update the `hackableApp` state. The quest information is updated during this process and the code editor and app level is in sync during this update cycle.

We need to find another way to fix the code editor update problem.

https://phabricator.endlessm.com/T30098