### PR TITLE
sidetrack: Don't update globalParameters on toolbox change

### DIFF
--- a/src/ui/test/sidetrack-quest.test.jsx
+++ b/src/ui/test/sidetrack-quest.test.jsx
@@ -273,7 +273,6 @@ const SidetrackQuest = () => {
         robotBDirection: params.robotBDirection,
       };
 
-      updateApp('globalParameters', params);
       updateApp(`globalLevel${params.currentLevel}Parameters`, currentLevel, () => {
         changeCallback(params);
       });


### PR DESCRIPTION
The sidetrack toolbox only changes the current level parameters:

 * instructionCode
 * levelCode
 * robots

We don't need to update the whole globalParameters with the current
state of the hackableApp. The globalParameters are updated when the
quest changes to change the level or play a cut scene.

This will fix some race-condition problems when the component changes
during the app load.

https://phabricator.endlessm.com/T30101