### PR TITLE
Dialogue: Pass current choice directly to libquest

### DIFF
--- a/src/ui/dialogue.jsx
+++ b/src/ui/dialogue.jsx
@@ -203,7 +203,7 @@ function useQuest(questContent) {
     if (currentChoice === null) return;
 
     if (currentChoice !== undefined) {
-      quest.choose(choices[currentChoice.index]);
+      quest.choose(currentChoice);
     }
 
     updateDialogueChoices();


### PR DESCRIPTION
The index can be messed up if there is a wait-for choice before the
current choice, because libquest filters those choices.

https://phabricator.endlessm.com/T30105