### PR TITLE
toolbox: Disable code editor autoclosing

### DIFF
--- a/src/ui/toolbox/panels/code.jsx
+++ b/src/ui/toolbox/panels/code.jsx
@@ -215,7 +215,7 @@ const CodePanel = ({
       onChange={build}
       name="editor"
       editorProps={{ $blockScrolling: true }}
-      setOptions={{ fixedWidthGutter: false }}
+      setOptions={{ fixedWidthGutter: false, behavioursEnabled: false }}
       wrapEnabled
       fontSize={14}
       showPrintMargin={false}


### PR DESCRIPTION
The ace editor has autocompletion and also autoclosing that's based on
the mode. The autoclosing is not configurable, so to disable that simple
autocompletion we should remove the behaviours added by the mode.

https://phabricator.endlessm.com/T30168