### PR TITLE
Update the document.title to match the topbar title

### DIFF
--- a/src/ui/app.jsx
+++ b/src/ui/app.jsx
@@ -1,5 +1,5 @@
 import { hot } from 'react-hot-loader';
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { ThemeProvider, CssBaseline } from '@material-ui/core';
 import {
   BrowserRouter as Router,
@@ -27,9 +27,13 @@ ReactGA.initialize('UA-160877903-1');
 const GAWrapper = ({ children }) => {
   const { location } = window;
 
-  if (process.env.NODE_ENV === 'production') {
-    ReactGA.pageview(location.pathname);
-  }
+  // This should be done in a effect to get the children component rendered so
+  // we've the final document.title setted
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      ReactGA.pageview(location.pathname);
+    }
+  }, [location.pathname]);
 
   return children;
 };

--- a/src/ui/hack-top-bar.jsx
+++ b/src/ui/hack-top-bar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import clsx from 'clsx';
 import { Link as RouterLink } from 'react-router-dom';
@@ -80,6 +80,11 @@ const HackTopBar = ({ title, subtitle, isMainPage }) => {
   const open = useSelector((state) => state.ui.sidePanelOpen);
   const dispatch = useDispatch();
   const { t, i18n } = useTranslation();
+
+  // Update the document title to match the current title
+  useEffect(() => {
+    document.title = `Hack - ${title}`;
+  }, [title]);
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);


### PR DESCRIPTION
The title give some information to the user and also to the google
analytics. This patch modifies the HackTopBar component to update the
document.title with the topbar title so we'll have the complete title in
the browser.

As a side effect we'll receive more information in the analytics,
because this title will be attached with the path and it's more
readable.

https://phabricator.endlessm.com/T30149