### PR TITLE
Add typescript-eslint/parser dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@neutrinojs/jest": "^9.1.0",
     "@neutrinojs/react": "^9.1.0",
     "@svgr/webpack": "^5.2.0",
+    "@typescript-eslint/parser": "^2.34.0",
     "aws-sdk": "^2.637.0",
     "babel-plugin-i18next-extract": "^0.7.2",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
There's a warning in the build telling us that the peer dependency is
not installed.

npm WARN @typescript-eslint/eslint-plugin@2.31.0 requires a peer of @typescript-eslint/parser@^2.0.0 but none is installed. You must install peer dependencies yourself.

This patch adds the typescript-eslint/parser package to the dev
dependencies to solve this problem.

https://phabricator.endlessm.com/T29832