### PR TITLE
CI: Invalidate cloudfront cache on deploy

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -9,6 +9,11 @@ const s3 = new AWS.S3({
   secretAccessKey: process.env.SECRET,
   region: 'us-east-2',
 });
+const cloudFront = new AWS.CloudFront({
+  accessKeyId: process.env.KEY,
+  secretAccessKey: process.env.SECRET,
+  region: 'us-east-2',
+});
 
 const fs = require('fs');
 const path = require('path');
@@ -52,3 +57,23 @@ getFiles('build')
     });
   })
   .catch((e) => console.error(e));
+
+// Invalidating CloudFront distribution cache
+if (branch === 'stable') {
+  console.log('Invalidating cloudfront cache...');
+  cloudFront.createInvalidation({
+    DistributionId: 'E16ECAJWT8UJVA',
+    InvalidationBatch: {
+      CallerReference: (+new Date()).toString(),
+      Paths: {
+        Quantity: 1,
+        Items: [ '/index.html' ],
+      },
+    },
+  }, (err, data) => {
+    if (err)
+      console.log(err, err.stack);
+    else
+      console.log('Cloudfront cache invalidated');
+  });
+}


### PR DESCRIPTION
Cloudfront caches S3 for 24h, we should invalidate the cache every time
we upload a new stable release.

https://phabricator.endlessm.com/T30081