### PR TITLE
CI: Use node-12 (LTS) docker image

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,5 @@
-FROM node:buster-slim
+# Using node 12 that's LTS
+FROM node:12-buster-slim
 
 RUN apt-get update && \
     apt-get -y install git unzip mono-runtime wget && \


### PR DESCRIPTION
This will fix the `yarn test` problem in the deployment because it's a
bug in the node >13.13:
https://github.com/JeffreyWay/laravel-mix/issues/2383

https://phabricator.endlessm.com/T29832