### PR TITLE
SidePanel: Fix quest buttons layout for webkit browsers

### DIFF
--- a/src/ui/quest-fth-view.jsx
+++ b/src/ui/quest-fth-view.jsx
@@ -252,14 +252,7 @@ const QuestFTHView = ({
         anchor="right"
         open={open}
       >
-        <Box
-          display="flex"
-          flexDirection="column"
-          alignItems="stretch"
-          height="100%"
-        >
-          {sidebar}
-        </Box>
+        {sidebar}
       </Drawer>
     </div>
   );

--- a/src/ui/side-panel.jsx
+++ b/src/ui/side-panel.jsx
@@ -59,23 +59,30 @@ const SidePanel = ({
   const isExpanded = isSmall ? false : expanded;
 
   return (
-    <>
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="stretch"
+      height="100%"
+    >
       <div className={clsx(classes.offset, isExpanded && classes.offsetExpanded)} />
       <Divider />
       <Box className={clsx(classes.dialogue, isExpanded && classes.dialogueExpanded)} px={1} py={2}>
         {content}
       </Box>
       <Divider />
-      <Box
-        my={1}
-        mr={2}
-        display="flex"
-        flexWrap="wrap"
-        justifyContent="flex-end"
-      >
-        {buttons}
+      <Box>
+        <Box
+          my={1}
+          mr={2}
+          display="flex"
+          flexWrap="wrap"
+          justifyContent="flex-end"
+        >
+          {buttons}
+        </Box>
       </Box>
-    </>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Just like in f7cff1f2 . It seems that flexbox containers can't be
items of another flexbox container in these browsers, so they have to
be wrapped in a empty div.

Also, move the flexbox container from QuestFTHView to the SidePanel
component.

https://phabricator.endlessm.com/T30199