### PR TITLE
ui: Fix useCard store selector with empty state

### DIFF
--- a/src/ui/hack-card.jsx
+++ b/src/ui/hack-card.jsx
@@ -212,6 +212,19 @@ function useCard() {
 
   return useSelector((state) => {
     const cardset = state.cardsets.find((cs) => cs.slug === '/home');
+
+    if (!cardset) {
+      // default state if it's not initialized yet, this is needed because with
+      // translations the cardset is lazy loaded and we can try to get the current
+      // quest card when the cardset is undefined
+      return {
+        slug: '',
+        name: '',
+        subtitle: '',
+        description: '',
+      };
+    }
+
     return cardset.cards.find((c) => slug === c.slug);
   });
 }


### PR DESCRIPTION
With the translations change we made the cardset state empty by default
and it's filled just after the i18n is initialized. This introduces a
problem in direct routing to quests because the useCard fails, the
cardset is undefined and we can't access to the cards attribute.

This patch just adds a check for that case and if the cardset is
undefined it returns a default empty card state. This will fix the
direct quest loading for example:

http://localhost:5000/art

https://phabricator.endlessm.com/T30221