### PR TITLE
App: Pass the search URL part to Google Analytics

### DIFF
--- a/src/ui/app.jsx
+++ b/src/ui/app.jsx
@@ -32,9 +32,9 @@ const GAWrapper = ({ children }) => {
   // we've the final document.title setted
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
-      ReactGA.pageview(location.pathname);
+      ReactGA.pageview(location.pathname + location.search);
     }
-  }, [location.pathname]);
+  }, [location.pathname, location.search]);
 
   return children;
 };


### PR DESCRIPTION
This is needed to record UTM parameters for marketing.

https://phabricator.endlessm.com/T30338