### PR TITLE
sidetrack: Fix restartApp

### DIFF
--- a/src/ui/quests/sidetrack-quest.jsx
+++ b/src/ui/quests/sidetrack-quest.jsx
@@ -373,14 +373,26 @@ const SidetrackQuest = () => {
     />
   );
 
+  const resetAllLevels = () => {
+    const app = appRef.current.contentWindow;
+    Array.from({ length: app.globalParameters.highestAchievedLevel + 1 })
+      .forEach((v, i) => {
+        const level = app.defaultLevelParameters.find((l) => l.level === i);
+        if (level) {
+          app[`globalLevel${i}Parameters`].instructionCode = level.instructionCode;
+          app[`globalLevel${i}Parameters`].levelCode = level.levelCode;
+        }
+      });
+  };
+
   const restartApp = () => {
     const { originalHackableApp } = store.getState();
     const { startLevel, highestAchievedLevel } = originalHackableApp;
     const app = appRef.current.contentWindow;
 
+    resetAllLevels();
     app.globalParameters.highestAchievedLevel = highestAchievedLevel;
-    const level = app[`globalLevel${startLevel}Parameters`];
-    app.game.scene.start('Game', level);
+    app.globalParameters.startLevel = startLevel;
   };
 
   const onRestartSelected = () => {


### PR DESCRIPTION
Restart should update the startLevel, in other case, it's not possible
to go back to the previous startLevel in the future.

This commit also resets the instructionCode and levelCode for each level
on restartApp so if we reach the same level we'll get the initial state
and not the solved state.

https://phabricator.endlessm.com/T30364