### PR TITLE
sidetrack: Remove level and robots from toolbox

### DIFF
--- a/src/ui/toolbox/dynamic.jsx
+++ b/src/ui/toolbox/dynamic.jsx
@@ -51,8 +51,8 @@ const ToolBoxGrid = ({
                 textColor="primary"
                 aria-label="Toolbox tabs"
               >
-                { toolbox.tabs.map(({ name, icon }) => (
-                  <Tab key={name} label={name} icon={icon} />
+                { toolbox.tabs.map(({ name, icon, disabled }) => (
+                  <Tab key={name} label={name} icon={icon} disabled={disabled} />
                 )) }
               </Tabs>
             </Box>

--- a/src/ui/toolbox/sidetrack.jsx
+++ b/src/ui/toolbox/sidetrack.jsx
@@ -239,6 +239,7 @@ const TOOLBOX = {
     {
       name: 'Level',
       icon: <Casino />,
+      disabled: true,
       grid: [
         {
           title: 'Code',
@@ -256,6 +257,7 @@ const TOOLBOX = {
     {
       name: 'Robots',
       icon: <BugReport />,
+      disabled: true,
       grid: [
         {
           title: 'Robots',

--- a/src/ui/toolbox/theme.jsx
+++ b/src/ui/toolbox/theme.jsx
@@ -17,6 +17,9 @@ const theme = createMuiTheme({
         '@media (min-width: 600px)': {
           minWidth: 72,
         },
+        '&:disabled': {
+          opacity: 0.2,
+        },
       },
     },
     MuiPopover: {


### PR DESCRIPTION
The current quests doesn't use the level and robots tabs in the
sidetrack toolbox. This patch removes those tabs.

We can bring back those tabs in the future if we add something else to
the sidetrack quest.

https://phabricator.endlessm.com/T30365