### PR TITLE
Toolbox code panel: Revert gutter fixed width

### DIFF
--- a/src/ui/toolbox/panels/code.jsx
+++ b/src/ui/toolbox/panels/code.jsx
@@ -68,13 +68,6 @@ const useStyles = makeStyles(({ spacing, zIndex, palette }) => ({
     },
     '& .ace_gutter': {
       backgroundColor: 'rgba(39, 40, 34, 0.8)',
-      width: `${spacing(10)}px !important`,
-    },
-    '& .ace_scroller': {
-      left: `${spacing(10)}px !important`,
-    },
-    '& .ace_gutter-layer': {
-      width: `${spacing(10)}px !important`,
     },
   },
   errorHighlight: {
@@ -231,7 +224,7 @@ const CodePanel = ({
       onChange={build}
       name="editor"
       editorProps={{ $blockScrolling: true }}
-      setOptions={{ fixedWidthGutter: false, behavioursEnabled: false }}
+      setOptions={{ behavioursEnabled: false }}
       wrapEnabled
       fontSize={14}
       showPrintMargin={false}


### PR DESCRIPTION
This is a manual revert of 86628fc1. Messing the CSS of the Ace editor
is bad, because everything inside the editor is calculated, so text
gets offset and outside the view.

https://phabricator.endlessm.com/T30383