### PR TITLE
dialog: Add custom class for achievements messages

### DIFF
--- a/src/libquest.js
+++ b/src/libquest.js
@@ -239,6 +239,7 @@ export default class Quest {
         text: html,
         character: extractLineCharacter(this.story.currentTags)
                 || this.mainCharacter,
+        achievement,
       };
 
       dialogue = [...dialogue, d];

--- a/src/ui/chat-message.jsx
+++ b/src/ui/chat-message.jsx
@@ -151,6 +151,14 @@ const useStyles = makeStyles(({
       borderTopRightRadius: 0,
       backgroundColor: palette.grey[300],
     },
+    achievement: {
+      '& img': {
+        width: spacing(20),
+        height: spacing(20),
+        margin: '0 auto',
+        display: 'block',
+      },
+    },
   };
 });
 
@@ -197,7 +205,12 @@ const ChatMessage = ({
                   styles[side],
                 )}
               >
-                <Box my={side === 'left' ? 1.5 : 0}>
+                <Box
+                  my={side === 'left' ? 1.5 : 0}
+                  className={clsx({
+                    [styles.achievement]: !!message.achievement,
+                  })}
+                >
                   {typing ? (<div />) : (
                     <>
                       <Typography dangerouslySetInnerHTML={{ __html: sanitize(message.text) }} />


### PR DESCRIPTION
Achievement messages have an image in the html code. This image takes
some time to render and sometimes the scroll is done before the image is
completely loaded, causing the scroll problem.

To fix this we can set a fixed width/height, so the `img` element always
has the same size and the browser will scroll correctly even if the img
loading takes some time.

This patch adds a new class for achievements messages and sets a fixed
width and height.

It's done this way, instead of applying the same style for all messages
to avoid forcing this style for possible quest messages with images.

With this change it's also possible to add move custom styles for
different message types, like messages with snippets.

https://phabricator.endlessm.com/T30335