### PR TITLE
side-panel: Remove horizontal scrolling bar

### DIFF
--- a/src/ui/side-panel.jsx
+++ b/src/ui/side-panel.jsx
@@ -74,6 +74,7 @@ const useStyles = makeStyles(({ palette, spacing, transitions }) => ({
     '& img': {
       width: spacing(10),
       height: spacing(10),
+      margin: spacing(0.5),
     },
     background: 'linear-gradient(to top, #212625, transparent)',
   },
@@ -98,7 +99,7 @@ const CardBadges = ({ card }) => {
   }
 
   return (
-    <Grid container direction="row" className={classes.badges} spacing={1}>
+    <Grid container direction="row" className={classes.badges}>
       <Grid item>
         <img src={`/assets/avatars/${card.character}.svg`} alt={card.character} />
       </Grid>


### PR DESCRIPTION
The spacing in the Grid causes an overflow so we've an horizontal
scrollbar in the component. Moving the spacing to the image css as
margin fixes the problem and maintain the same spacing between badges.

https://phabricator.endlessm.com/T30386