### PR TITLE
CookieBanner: Remove autofocus from "Allow" button

### DIFF
--- a/src/ui/cookie-banner.jsx
+++ b/src/ui/cookie-banner.jsx
@@ -115,7 +115,7 @@ const CookieBanner = () => {
                   </HackButton>
                 </Box>
                 <Box mx={1}>
-                  <MainButton onClick={handleClose} variant="contained" color="primary" autoFocus>
+                  <MainButton onClick={handleClose} variant="contained">
                     {t('Allow')}
                   </MainButton>
                 </Box>


### PR DESCRIPTION
Also, remove the unneded color setting. MainButton already uses the
primary color.

https://phabricator.endlessm.com/T30222