### PR TITLE
Sidetrack cleanup and change restoration

### DIFF
--- a/src/ui/quests/sidetrack-1-quest.ink
+++ b/src/ui/quests/sidetrack-1-quest.ink
@@ -2,6 +2,7 @@
 - Let's go! Remember, my objective is to get to the exit, and try to avoid the walls!
 -> end_level_check(3) -> level3_1
 
+
 === level3_1 ===
 # character: ada
 - Hey, {get_user_name()}, did you know that Riley actually made this game?
@@ -26,11 +27,11 @@
 - Um, let's concentrate on beating this level, {get_user_name()}!
 -> end_level_check(4) -> level4
 
+
 === level4 ===
 # character: saniel
 -Oh ho! <b>Pits</b>, eh? I wonder how you'll cross those...
 -> mid_level_check(5) -> level4_1
-
 
 === level4_1 ===
 -You need to use the <b>Jump</b> instruction to cross <b>Pits</b>! There's a trick to it, though. <b>Jump</b> can only cross a <b>pit</b> if it's <b>directly</b> in front of you.
@@ -45,7 +46,6 @@
 -BTW, those pits weren't easy to draw... it's tough trying to get that feeling of a deep, black hole, but only using colors.
 -> mid_level_check(7) -> level6_1
 
-
 === level6_1 ===
 # character: ada
 -Riley, you did extremely well. I wish every student had your drive!
@@ -57,13 +57,9 @@
 -Hey Riley, I think your game has some <b>bugs</b>, LOL! What a cool bunch of robots. <tt>Beep. Boop. Hello. Faber. I. Am. A. Bugbot.</tt>
 -> mid_level_check(8) -> level7_1
 
-
-
 === level7_1 ===
 -I knew you'd like that one, Faber :D
 -> mid_level_check(8) -> level7_2
-
-
 
 === level7_2===
 # character: estelle
@@ -119,28 +115,23 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 -What was <b>that</b>? Riley?
 -> mid_level_check(15) -> level14_postcs_2
 
-
 === level14_postcs_2 ===
 # character: ada
 -I think we have a problem! Riley, it looks like the controls just disappeared. Any ideas?
 -> mid_level_check(15) -> level14_postcs_3
 
-
 === level14_postcs_3 ===
 - I was wondering when Felix would show up! For once, he's on time, and doing exactly what I asked him to. <b>Now</b> things are going to get interesting!
 -> mid_level_check(15) -> level14_postcs_4
-
 
 === level14_postcs_4 ===
 # character: estelle
 -Look, {get_user_name()} - there's a pre-made set of instructions already here.
 -> mid_level_check(15) -> level14_postcs_5
 
-
 === level14_postcs_5 ===
 -And now, we're in hard-mode! See that <b>Play</b> button on the left? Try pushing it.
 -> end_level_check(15) -> level15
-
 
 
 === level15 ===
@@ -153,11 +144,9 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 -Hmm, there's no way these instructions could finish this level in this order! You'll have to re-order them to get through.
 -> mid_level_check(17) -> level16_2
 
-
 === level16_2 ===
 - Drag and drop the instructions to re-order them, and press <b>Play</b> to start your run! Oh yeah, and once you press play... no changing instructions around until you succeed or fail!
 -> end_level_check(17) -> level17
-
 
 
 === level17 ===
@@ -165,12 +154,10 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 -Fantastic work, you practically sailed through that level, {get_user_name()}. Excellent planning!
 -> mid_level_check(18) -> level17_2
 
-
 === level17_2 ===
 # character: saniel
 - Riley, I can see the progression from puzzle-solving to strategic planning in this game, and I'm impressed.
 -> mid_level_check(18) -> level17_3
-
 
 === level17_3 ===
 -Woah, t-thanks, Saniel! That means a lot to me.
@@ -182,11 +169,9 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 -Hey Riley, how's your maze going?
 -> mid_level_check(19) -> level18_2
 
-
 === level18_2 ===
 -It's pretty... a-maze-ing! :D Seriously, {get_user_name()} I hope you're having as much fun as we are. It's so cool to see someone play something I helped build!
 -> mid_level_check(19) -> level18_3
-
 
 === level18_3 ===
 # character: ada
@@ -197,7 +182,6 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 === level19 ===
 -Let's turn the heat up - now you've got 2 Jumps.
 -> mid_level_check(20) -> level19_2
-
 
 === level19_2 ===
 # character: ada

--- a/src/ui/quests/sidetrack-1-quest.ink
+++ b/src/ui/quests/sidetrack-1-quest.ink
@@ -69,7 +69,6 @@
 -> mid_level_check(8) -> level7_3
 
 === level7_3 ===
-# character: riley
 - These bugbots <b>only move down</b>, never left or right, so that might let you find a... bug... in their behavior. ^_^
 - Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your eye out for that!
 -> end_level_check(8) -> level8

--- a/src/ui/quests/sidetrack-1-quest.ink
+++ b/src/ui/quests/sidetrack-1-quest.ink
@@ -30,11 +30,11 @@
 
 === level4 ===
 # character: saniel
--Oh ho! <b>Pits</b>, eh? I wonder how you'll cross those...
+- Oh ho! <b>Pits</b>, eh? I wonder how you'll cross those...
 -> mid_level_check(5) -> level4_1
 
 === level4_1 ===
--You need to use the <b>Jump</b> instruction to cross <b>Pits</b>! There's a trick to it, though. <b>Jump</b> can only cross a <b>pit</b> if it's <b>directly</b> in front of you.
+- You need to use the <b>Jump</b> instruction to cross <b>Pits</b>! There's a trick to it, though. <b>Jump</b> can only cross a <b>pit</b> if it's <b>directly</b> in front of you.
 -> end_level_check(5) -> level5
 
 
@@ -43,35 +43,35 @@
 
 
 === level6 ===
--BTW, those pits weren't easy to draw... it's tough trying to get that feeling of a deep, black hole, but only using colors.
+- BTW, those pits weren't easy to draw... it's tough trying to get that feeling of a deep, black hole, but only using colors.
 -> mid_level_check(7) -> level6_1
 
 === level6_1 ===
 # character: ada
--Riley, you did extremely well. I wish every student had your drive!
+- Riley, you did extremely well. I wish every student had your drive!
 -> end_level_check(7) -> level7
 
 
 === level7 ===
 # character: faber
--Hey Riley, I think your game has some <b>bugs</b>, LOL! What a cool bunch of robots. <tt>Beep. Boop. Hello. Faber. I. Am. A. Bugbot.</tt>
+- Hey Riley, I think your game has some <b>bugs</b>, LOL! What a cool bunch of robots. <tt>Beep. Boop. Hello. Faber. I. Am. A. Bugbot.</tt>
 -> mid_level_check(8) -> level7_1
 
 === level7_1 ===
--I knew you'd like that one, Faber :D
+- I knew you'd like that one, Faber :D
 -> mid_level_check(8) -> level7_2
 
 === level7_2===
 # character: estelle
--Stay alert, {get_user_name()}! The bugbots move when you do, so you'll have to plan out your moves carefully.
+- Stay alert, {get_user_name()}! The bugbots move when you do, so you'll have to plan out your moves carefully.
 # character: estelle
--Watch how the bugbots move and where they go, and think about the spaces they open up when they move.
+- Watch how the bugbots move and where they go, and think about the spaces they open up when they move.
 -> mid_level_check(8) -> level7_3
 
 === level7_3 ===
-# character: estelle
--These bugbots <b>only move down</b>, never left or right, so that might let you find a... bug... in their behavior. ^_^
-Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your eye out for that!
+# character: riley
+- These bugbots <b>only move down</b>, never left or right, so that might let you find a... bug... in their behavior. ^_^
+- Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your eye out for that!
 -> end_level_check(8) -> level8
 
 
@@ -84,7 +84,7 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 
 
 === level10 ===
--Time for new bugbots! This new type <b>only moves up</b>, just like the first <b>only moves down</b>. Pay attention to which way they're facing!
+- Time for new bugbots! This new type <b>only moves up</b>, just like the first <b>only moves down</b>. Pay attention to which way they're facing!
 -> end_level_check(11) -> level11
 
 
@@ -98,7 +98,7 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 
 === level13 ===
 # character: ada
--Bugbots, pits... Riley, you've done a great job here.
+- Bugbots, pits... Riley, you've done a great job here.
 -> end_level_check(14) -> level14
 
 
@@ -112,12 +112,12 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 
 === level14_postcs ===
 # character: faber
--What was <b>that</b>? Riley?
+- What was <b>that</b>? Riley?
 -> mid_level_check(15) -> level14_postcs_2
 
 === level14_postcs_2 ===
 # character: ada
--I think we have a problem! Riley, it looks like the controls just disappeared. Any ideas?
+- I think we have a problem! Riley, it looks like the controls just disappeared. Any ideas?
 -> mid_level_check(15) -> level14_postcs_3
 
 === level14_postcs_3 ===
@@ -126,22 +126,22 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 
 === level14_postcs_4 ===
 # character: estelle
--Look, {get_user_name()} - there's a pre-made set of instructions already here.
+- Look, {get_user_name()} - there's a pre-made set of instructions already here.
 -> mid_level_check(15) -> level14_postcs_5
 
 === level14_postcs_5 ===
--And now, we're in hard-mode! See that <b>Play</b> button on the left? Try pushing it.
+- And now, we're in hard-mode! See that <b>Play</b> button on the left? Try pushing it.
 -> end_level_check(15) -> level15
 
 
 === level15 ===
--In this mode, you have to plan all your moves around the level in advance. Drag the instructions into the order you want, then press <b>play</b> to start our journey through the maze. If you think it through, you'll pass these levels in no time.
+- In this mode, you have to plan all your moves around the level in advance. Drag the instructions into the order you want, then press <b>play</b> to start our journey through the maze. If you think it through, you'll pass these levels in no time.
 -> end_level_check(16) -> level16
 
 
 === level16 ===
 # character: saniel
--Hmm, there's no way these instructions could finish this level in this order! You'll have to re-order them to get through.
+- Hmm, there's no way these instructions could finish this level in this order! You'll have to re-order them to get through.
 -> mid_level_check(17) -> level16_2
 
 === level16_2 ===
@@ -151,7 +151,7 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 
 === level17 ===
 # character: saniel
--Fantastic work, you practically sailed through that level, {get_user_name()}. Excellent planning!
+- Fantastic work, you practically sailed through that level, {get_user_name()}. Excellent planning!
 -> mid_level_check(18) -> level17_2
 
 === level17_2 ===
@@ -160,32 +160,32 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 -> mid_level_check(18) -> level17_3
 
 === level17_3 ===
--Woah, t-thanks, Saniel! That means a lot to me.
+- Woah, t-thanks, Saniel! That means a lot to me.
 -> end_level_check(18) -> level18
 
 
 === level18 ===
 # character: faber
--Hey Riley, how's your maze going?
+- Hey Riley, how's your maze going?
 -> mid_level_check(19) -> level18_2
 
 === level18_2 ===
--It's pretty... a-maze-ing! :D Seriously, {get_user_name()} I hope you're having as much fun as we are. It's so cool to see someone play something I helped build!
+- It's pretty... a-maze-ing! :D Seriously, {get_user_name()}, I hope you're having as much fun as we are. It's so cool to see someone play something I helped build!
 -> mid_level_check(19) -> level18_3
 
 === level18_3 ===
 # character: ada
--Ah hah, look at your instructions carefully. You've only got one jump, so use it well - you might need to use a different way of getting around the pits.
+- Look at your instructions carefully! You've only got one jump, so use it well - you might need to use a different way of getting around the pits.
 -> end_level_check(19) -> level19
 
 
 === level19 ===
--Let's turn the heat up - now you've got 2 Jumps.
+- Let's turn up the heat - now you've got 2 Jumps.
 -> mid_level_check(20) -> level19_2
 
 === level19_2 ===
 # character: ada
--This level might look easier, but now you only have a single forward instruction. I think there's only one spot in this level that you absolutely <b>must</b> move forward, and not down or up. Can you find it?
+- This level might look easier, but now you only have a single forward instruction. I think there's only one spot in this level that you absolutely <b>must</b> move forward, and not down or up. Can you find it?
 -> end_level_check(20) -> level20
 
 
@@ -197,10 +197,10 @@ Oh yeah, when they walk off the bottom, they reappear at the top! So, keep your 
 
 === level21 ===
 # character: ada
--You know, you don't have to have a pit in front of you to use a <b>jump</b> instruction. Maybe you could use a <b>jump</b> to go forward? You never know when that will come in handy!
+- You know, you don't have to have a pit in front of you to use a <b>jump</b> instruction. Maybe you could use a <b>jump</b> to go forward? You never know when that will come in handy!
 -> end_level_check(22) ->
-You sailed through all those levels. For that, I'm giving you a reward.
-~ set_game_state("quests.achievements/sidetrack1-complete", true)
+- Wow, fantastic job, {get_user_name()}! That's 21 levels solved! Let's celebrate your progress with a Badge!
+~ set_game_state("quests.achievements/sidetrack1- complete", true)
 ~ set_game_state("quest.Sidetrack1/complete", true)
 * ❯
   -> hack

--- a/src/ui/quests/sidetrack-1-quest.ink
+++ b/src/ui/quests/sidetrack-1-quest.ink
@@ -200,7 +200,7 @@
 - You know, you don't have to have a pit in front of you to use a <b>jump</b> instruction. Maybe you could use a <b>jump</b> to go forward? You never know when that will come in handy!
 -> end_level_check(22) ->
 - Wow, fantastic job, {get_user_name()}! That's 21 levels solved! Let's celebrate your progress with a Badge!
-~ set_game_state("quests.achievements/sidetrack1- complete", true)
+~ set_game_state("quests.achievements/sidetrack1-complete", true)
 ~ set_game_state("quest.Sidetrack1/complete", true)
 * ❯
   -> hack

--- a/src/ui/quests/sidetrack-2-quest.ink
+++ b/src/ui/quests/sidetrack-2-quest.ink
@@ -55,15 +55,15 @@
 
 
 === level23_5 ===
-~ attractFTH = 1
 - Exactly, Dr. Rowe! That's what the next step is - debug the broken code! Do you see that button on the <b>left side</b> of the screen, {get_user_name()}? That's the <b>Flip to Hack</b> button! You can use it to go behind the scenes and hack the game with the <b>Toolbox</b>. Let's go!
 {flipped: -> level23_8}
+~ attractFTH = 1
 * [(wait for: flipped)]  Flipped!
+~ attractFTH = 0
 -> level23_8
 
 
 === level23_8 ===
-~ attractFTH = 0
 ~ hasLockKey = 1
 - There's a lock here, but never fear, {get_user_name()}, here's the key! Click the lock to open it, and you'll be able to see the <b>Instructions</b>. They're the code version of the icons you dragged around on the front side of Sidetrack.
 * [(wait for: isLocked is 0)]  Unlocked!
@@ -98,37 +98,37 @@
 
 === level23_flip ===
 {not flipped: -> level23_play}
-~ attractFTH = 1
 - Now <b>flip</b> back to the front of Sidetrack.
+~ attractFTH = 1
 * [(wait for: flipped)]  Flipped back!
+~ attractFTH = 0
 -> level23_play
 * [(wait for: currentLevel is 24)] Level {currentLevel-1} Complete!
+~ attractFTH = 0
 -> level24
 
 === level23_play ===
-~ attractFTH = 0
 - Ok, press the <b>Play</b> button!
 * [(wait for: currentLevel is 24)] Level {currentLevel-1} Complete!
 -> level24
 
 === level24 ===
-~ attractFTH = 1
-# character: riley
+
 - I've been saving this badge for you, {get_user_name()} - You really know your way around Sidetrack now!
 ~ set_game_state("quests.achievements/sidetrack2-complete", true)
 - There are still plenty of challenges ahead, though. Let's keep going, <b>flip</b> the app and hack the <b>Instructions</b> again!
+~ attractFTH = 1
 * [(wait for: flipped)] Flipped!
+~ attractFTH = 0
 -> level24_3
-* [(wait for: currentLevel is 25)] #
+* [(wait for: currentLevel is 25)] Level {currentLevel-1} Complete!
+~ attractFTH = 0
 # character: saniel
 - Gibbering heffalumps! That's quite a gambit, {get_user_name()}! I think I might say... how does it go... that "you're the man now, dog!"
-# character: user
-- Level {currentLevel-1} Complete!
 -> level25
 
 
 === level24_3 ===
-~ attractFTH = 0
 - I think I can see the problem here!
 * [Hint] (Hint)
 -> level24_3_hints
@@ -140,15 +140,15 @@
 
 === level24_flip ===
 {not flipped: -> level24_play}
-~ attractFTH = 1
 # character: saniel
 - Good. You've corrected the errors, now <b>flip</b> back to the front of Sidetrack.
+~ attractFTH = 1
 * [(wait for: flipped)]  Flipped back!
+~ attractFTH = 0
 -> level24_play
 
 
 === level24_play ===
-~ attractFTH = 0
 # character: estelle
 - Ok, let's give it a shot. Press the <b>Play</b> button! If you don't make it through, you might need different instructions, or a different order of instructions.
 * [(wait for: currentLevel is 25)] Level {currentLevel-1} Complete!
@@ -187,7 +187,6 @@
 
 
 === level25 ===
-~ attractFTH = 0
 # character: estelle
 - Riley, did you remember to test your code? We've hit quite a lot of errors!
 * [(wait for: codeErrors is 0)] Fixed it!
@@ -208,6 +207,8 @@
 - I don't think these errors are a mistake! Every instruction in this set is wrong, and statistically, that's very unlikely.
 * ❯
 -> level26_2
+* [(wait for: flipped)] Flipped!
+-> level26_2
 * [(wait for: currentLevel is 27)] Level {currentLevel-1} Complete!
 -> level26_2
 
@@ -215,17 +216,9 @@
 === level26_2 ===
 - Yeah, almost like... it's intentional... :D
 # character: felix
-- <b><i>m*::>^_^<::&rr0w>!</i></b>
+- <b><i>m*:3:3&rr0w!</i></b>
 - You said it, Felix! Hey {get_user_name()}, you know the drill now! <b>Flip</b> and hack!
-{not flipped: -> level26_3}
-* [(wait for: flipped)] Flipped!
--> level26_3
-* [(wait for: currentLevel is 27)] Level {currentLevel-1} Complete!
--> level27
-
-
-=== level26_3 ===
-* [(wait for: codeErrors is 0)] Fixed it!
+* [(wait for: codeErrors is 0)] Fixed!
 -> level26_fix
 * [(wait for: currentLevel is 27)] Level {currentLevel-1} Complete!
 -> level27

--- a/src/ui/quests/sidetrack-2-quest.ink
+++ b/src/ui/quests/sidetrack-2-quest.ink
@@ -1,6 +1,6 @@
 === hack ===
 { not skip:
-    Ok, let's see what this level is about... # character: ada
+    Congratulations on your badge, {get_user_name()}! Now, let's see what this level is about... # character: ada
 }
 * [(wait for: currentLevel is 23)] Level {currentLevel -1 } Complete!
 -> level23
@@ -9,7 +9,6 @@
 - Hey, check out that instruction in the middle of the set. That's not a good symbol!
 # character: ada
 - I suppose we should try out the level anyway, just to see what happens...
--> level23_2
 * [(wait for: success is 0)] Level {currentLevel} Failed!
 -> level23_fail
 * [(wait for: flipped)] Flipped!
@@ -31,70 +30,70 @@
 # character: estelle
 - Good thing I know just the person to help! Saniel, are you there?
 { flipped == true:
-	-> level23_cont_3
+	-> level23_3
 }
 * ❯
--> level23_cont_3
+-> level23_3
 * [(wait for: flipped)] Flipped!
--> level23_cont_3
+-> level23_3
 
 
-=== level23_cont_3 ===
+=== level23_3 ===
 # character: saniel
 - What? Yes, yes, I am here. I was... <i>inemuri</i>, as the Japanese say. Sleeping while present, if you will.
 { flipped == true:
-	-> level23_cont_4
+	-> level23_4
 }
 * ❯
--> level23_cont_4
+-> level23_4
 * [(wait for: flipped)] Flipped!
--> level23_cont_4
+-> level23_4
 
 
-=== level23_cont_4 ===
+=== level23_4 ===
 # character: saniel
 - Ahem. Now, what do we have? A line of pits, an invalid instruction... It <b>appears</b> we're stuck, but we won't be defeated this easily! Riley, is there a way for us to look into the code and debug that instruction?
 { flipped == true:
-	-> level23_cont_5
+	-> level23_5
 }
 * ❯
--> level23_cont_5
+-> level23_5
 * [(wait for: flipped)] Flipped!
--> level23_cont_5
+-> level23_5
 
 
-=== level23_cont_5 ===
+=== level23_5 ===
 ~ attractFTH = 1
 - Exactly, Dr. Rowe! That's what the next step is - debug the broken code! Do you see that button on the <b>left side</b> of the screen, {get_user_name()}? That's the <b>Flip to Hack</b> button! You can use it to go behind the scenes and hack the game with the <b>Toolbox</b>. Let's go!
 { flipped:
-	-> level23_cont_8
+	-> level23_8
 }
 * [(wait for: flipped)]  Flipped!
--> level23_cont_8
+-> level23_8
 
 
-=== level23_cont_8 ===
+=== level23_8 ===
 ~ attractFTH = 0
 ~ hasLockKey = 1
 - There's a lock here, but never fear, {get_user_name()}, here's the key! Click the lock to open it, and you'll be able to see the <b>Instructions</b>. They're the code version of the icons you dragged around on the front side of Sidetrack.
 * [(wait for: isLocked is 0)]  Unlocked!
--> level23_cont_10
+-> level23_10
 * [(wait for: currentLevel is 24)] Level {currentLevel -1} Complete!
 -> level24
 
 
-=== level23_cont_10 ===
+=== level23_10 ===
 - Take a close look at the instructions. If you see anything weird, try and fix it.
 - You can always Undo any mistakes you make (<b>Ctrl + Z</b>), and if everything get really bad, you can always reset the code by clicking the <b>Reload</b> button in the upper right. Got it?
-* [👍] I think I see the problem!
--> level23_cont_11
+* [👍] Gotcha!
+-> level23_11
 * [👎] I'm a little lost.
--> level23_cont_12
+-> level23_12
 * [(wait for: codeErrors is 0)] Fixed it!
 -> level23_flip
 
 
-=== level23_cont_12 ===
+=== level23_12 ===
 # character: ada
 - Look at that middle instruction, {get_user_name()}. I'm pretty sure <b>jumpp</b> isn't a real word - and I'm positive it's not a correct <b>instruction</b>, either! Fix that, <b>flip</b> back to the front of Sidetrack, and then press the <b>Play</b> button!
 * [(wait for: currentLevel is 24)] Level {currentLevel -1 } Complete!
@@ -102,7 +101,7 @@
 * [(wait for: codeErrors is 0)] Fixed it!
 -> level23_flip
 
-=== level23_cont_11 ===
+=== level23_11 ===
 - Awesome! Fix the problem, <b>flip</b> back to the front of Sidetrack, and then press the <b>Play</b> button!
 * [(wait for: codeErrors is 0)] Fixed it!
 -> level23_flip
@@ -112,6 +111,8 @@
 - Now <b>flip</b> back to the front of Sidetrack.
 * [(wait for: flipped)]  Flipped back!
 -> level23_play
+* [(wait for: currentLevel is 24)] Level {currentLevel -1} Complete!
+-> level24
 
 === level23_play ===
 ~ attractFTH = 0
@@ -122,18 +123,17 @@
 === level24 ===
 ~ attractFTH = 1
 # character: riley
-- Ah, much better! I see you've got a knack for hacking! For that, I'm giving you a reward.
-~ set_game_state("quests.achievements/sidetrack2-complete", true)
+- Great work! On to the next challenge!
 * ❯
 # character: faber
-- Wow, looks like this level has 2 errors! Time to <b>flip</b> the app and get to the <b>Instructions</b> again!
+- Yikes, looks like this level has 2 errors! Time to <b>flip</b> the app and get to the <b>Instructions</b> again!
 * [(wait for: flipped)] Flipped!
 -> level24_3
 * [(wait for: currentLevel is 25)] #
 # character: saniel
-Gibbering heffalumps! That's quite a gambit, {get_user_name()}! I think I might say... how does it go... that "you're the man now, dog!"
+- Gibbering heffalumps! That's quite a gambit, {get_user_name()}! I think I might say... how does it go... that "you're the man now, dog!"
 # character: user
-Level {currentLevel -1} Complete!
+- Level {currentLevel -1} Complete!
 -> level25
 
 
@@ -221,7 +221,10 @@ Level {currentLevel -1} Complete!
 
 
 === level26_2 ===
-- Hey {get_user_name()}, you know the drill now! <b>Flip</b> and hack!
+- Yeah, almost like... it's intentional... :D
+# character: felix
+- <b><i>m*::>^_^<::&rr0w>!</i></b>
+- You said it, Felix! Hey {get_user_name()}, you know the drill now! <b>Flip</b> and hack!
 * [(wait for: flipped)] Flipped!
 -> level26_3
 * [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
@@ -237,7 +240,7 @@ Level {currentLevel -1} Complete!
 
 === level26_fix ===
 # character: faber
-Just because you fixed the errors doesn't mean the instructions are correct, you'll probably have to re-order them... or maybe even re-write them completely!
+- Just because you fixed the errors doesn't mean the instructions are correct, you'll probably have to re-order them... or maybe even re-write them completely!
 * [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
 -> level27
 
@@ -278,6 +281,7 @@ Just because you fixed the errors doesn't mean the instructions are correct, you
 
 === level28_5 ===
 # character: saniel
+- Ahem. I think I speak for all of us, here, when I say that we've had a great time with you, {get_user_name()}. Here, take this badge as a reward for your excellent work. I hope we'll see you soon in Endless OS!
 ~ set_game_state("quest.Sidetrack2/complete", true)
-- Ahem. I think I speak for all of us, here, when I say that we've had a great time with you, {get_user_name()}. I hope we'll see you soon in Endless OS!
+~ set_game_state("quests.achievements/sidetrack2-complete", true)
 -> END

--- a/src/ui/quests/sidetrack-2-quest.ink
+++ b/src/ui/quests/sidetrack-2-quest.ink
@@ -4,33 +4,16 @@
 }
 * [(wait for: currentLevel is 23)] Level {currentLevel -1 } Complete!
 -> level23
-* [(wait for: success is 0)] Level {currentLevel} Failed!
--> level22_reorder
-
-
-=== level22_reorder ===
-# character: faber
-- I think we're going to need to rearrange the instructions until we get it right!
--> end_level_check(23) -> level23
 
 === level23 ===
 - Hey, check out that instruction in the middle of the set. That's not a good symbol!
-* ❯
+# character: ada
+- I suppose we should try out the level anyway, just to see what happens...
 -> level23_2
 * [(wait for: success is 0)] Level {currentLevel} Failed!
 -> level23_fail
 * [(wait for: flipped)] Flipped!
 -> level23_fail
-
-
-=== level23_2 ===
-# character: ada
-- Well, I suppose we should try out the level anyway, just to see what happens...
-* [(wait for: success is 0)] Level {currentLevel} Failed!
--> level23_fail
-* [(wait for: flipped)] Flipped!
--> level23_fail
-
 
 === level23_fail ===
 # character: estelle
@@ -70,7 +53,7 @@
 
 === level23_cont_4 ===
 # character: saniel
-- Let's see what we have. A line of pits, an invalid instruction... It <b>appears</b> we're stuck, but I don't think so! Riley, is there a way for us to look into the code and debug that instruction?
+- Ahem. Now, what do we have? A line of pits, an invalid instruction... It <b>appears</b> we're stuck, but we won't be defeated this easily! Riley, is there a way for us to look into the code and debug that instruction?
 { flipped == true:
 	-> level23_cont_5
 }
@@ -82,7 +65,7 @@
 
 === level23_cont_5 ===
 ~ attractFTH = 1
-- You got it, Dr. Rowe! That's exactly what the next step is. Do you see that button on the <b>left side</b> of the screen, {get_user_name()}? That's the <b>Flip to Hack</b> button! You can use it to go behind the scenes and hack the game with the <b>Toolbox</b>. Let's go!
+- Exactly, Dr. Rowe! That's what the next step is - debug the broken code! Do you see that button on the <b>left side</b> of the screen, {get_user_name()}? That's the <b>Flip to Hack</b> button! You can use it to go behind the scenes and hack the game with the <b>Toolbox</b>. Let's go!
 { flipped:
 	-> level23_cont_8
 }
@@ -101,7 +84,8 @@
 
 
 === level23_cont_10 ===
-- Take a close look at the instructions. When you write code, it has to be <b>exactly</b> how the computer expects... So, do you see anything weird? Try and fix any problems you see. You can always Undo any mistakes you make (<b>Ctrl + Z</b>), and if everything get really bad, you can always  reset the code by clicking the <b>Reload</b> button in the upper right.
+- Take a close look at the instructions. If you see anything weird, try and fix it.
+- You can always Undo any mistakes you make (<b>Ctrl + Z</b>), and if everything get really bad, you can always reset the code by clicking the <b>Reload</b> button in the upper right. Got it?
 * [👍] I think I see the problem!
 -> level23_cont_11
 * [👎] I'm a little lost.
@@ -125,13 +109,13 @@
 
 === level23_flip ===
 ~ attractFTH = 1
-- Awesome, I think you fixed it! Now <b>flip</b> back to the front of Sidetrack.
+- Now <b>flip</b> back to the front of Sidetrack.
 * [(wait for: flipped)]  Flipped back!
 -> level23_play
 
 === level23_play ===
 ~ attractFTH = 0
-- Ok, let's give it a shot! Press the <b>Play</b> button.
+- Ok, press the <b>Play</b> button!
 * [(wait for: currentLevel is 24)] Level {currentLevel -1} Complete!
 -> level24
 
@@ -145,7 +129,11 @@
 - Wow, looks like this level has 2 errors! Time to <b>flip</b> the app and get to the <b>Instructions</b> again!
 * [(wait for: flipped)] Flipped!
 -> level24_3
-* [(wait for: currentLevel is 25)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 25)] #
+# character: saniel
+Gibbering heffalumps! That's quite a gambit, {get_user_name()}! I think I might say... how does it go... that "you're the man now, dog!"
+# character: user
+Level {currentLevel -1} Complete!
 -> level25
 
 
@@ -163,7 +151,7 @@
 === level24_flip ===
 ~ attractFTH = 1
 # character: saniel
-- Awesome! No errors anymore. Now <b>flip</b> back to the front of Sidetrack.
+- Good. You've corrected the errors, now <b>flip</b> back to the front of Sidetrack.
 * [(wait for: flipped)]  Flipped back!
 -> level24_play
 
@@ -218,14 +206,14 @@
 
 === level25_fix ===
 # character: saniel
-- Nice work, you fixed it. Remember, now we need to <b>flip</b> back and check if you can get through the maze. If not, you might need different instructions.
+- Well done, you've fixed the errors. Now, <b>flip</b> back and see if you can complete the level. Don't forget that you might still need to re-order or change in instructions to get through.
 * [(wait for: currentLevel is 26)] Level {currentLevel -1} Complete!
 -> level26
 
 
 === level26 ===
 # character: ada
-- I'm not so sure these errors are a mistake, every instruction in this set is wrong! Statistically, the probability of that occurring is quite low.
+- I don't think these errors are a mistake! Every instruction in this set is wrong, and statistically, that's very unlikely.
 * ❯
 -> level26_2
 * [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
@@ -233,7 +221,7 @@
 
 
 === level26_2 ===
-- Now you're getting it! Head to the <b>Instructions</b> again by <b>flipping</b> Sidetrack!
+- Hey {get_user_name()}, you know the drill now! <b>Flip</b> and hack!
 * [(wait for: flipped)] Flipped!
 -> level26_3
 * [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
@@ -241,8 +229,6 @@
 
 
 === level26_3 ===
-# character: ada
-- Once you've fixed the errors, you still might need to re-order the instructions in order to beat this level.
 * [(wait for: codeErrors is 0)] Fixed it!
 -> level26_fix
 * [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
@@ -251,34 +237,14 @@
 
 === level26_fix ===
 # character: faber
-- Excellent!
+Just because you fixed the errors doesn't mean the instructions are correct, you'll probably have to re-order them... or maybe even re-write them completely!
 * [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
 -> level27
-* [(wait for: success is 0)] Level {currentLevel} Failed!
--> level26_reorder
-
-
-=== level26_reorder ===
-# character: faber
-- You'll need to rearrange the instructions until you get it right.
-* [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
--> level27
-* [(wait for: success is 0)] Level {currentLevel} Failed!
--> level26_reorder
 
 
 === level27 ===
 # character: ada
 - It looks like this level has only two incorrect instructions - that's an improvement.
-* [(wait for: codeErrors is 0)] Fixed it!
--> level27_fix
-* [(wait for: currentLevel is 28)] Level {currentLevel -1} Complete!
--> level28
-
-
-=== level27_fix ===
-# character: saniel
-- Great work. You've got it!
 * [(wait for: currentLevel is 28)] Level {currentLevel -1} Complete!
 -> level28
 

--- a/src/ui/quests/sidetrack-2-quest.ink
+++ b/src/ui/quests/sidetrack-2-quest.ink
@@ -17,9 +17,7 @@
 === level23_fail ===
 # character: estelle
 - I think we actually have 2 problems - First, the middle instruction looks like an error. Second, even if you put that error somewhere else, we still need a <b>jump()</b> to cross those pits!
-{ flipped == true:
-	-> level23_fail_2
-}
+{flipped: -> level23_fail_2}
 * ❯
 -> level23_fail_2
 * [(wait for: flipped)] Flipped!
@@ -29,9 +27,7 @@
 === level23_fail_2 ===
 # character: estelle
 - Good thing I know just the person to help! Saniel, are you there?
-{ flipped == true:
-	-> level23_3
-}
+{flipped: -> level23_3}
 * ❯
 -> level23_3
 * [(wait for: flipped)] Flipped!
@@ -41,9 +37,7 @@
 === level23_3 ===
 # character: saniel
 - What? Yes, yes, I am here. I was... <i>inemuri</i>, as the Japanese say. Sleeping while present, if you will.
-{ flipped == true:
-	-> level23_4
-}
+{flipped: -> level23_4}
 * ❯
 -> level23_4
 * [(wait for: flipped)] Flipped!
@@ -53,9 +47,7 @@
 === level23_4 ===
 # character: saniel
 - Ahem. Now, what do we have? A line of pits, an invalid instruction... It <b>appears</b> we're stuck, but we won't be defeated this easily! Riley, is there a way for us to look into the code and debug that instruction?
-{ flipped == true:
-	-> level23_5
-}
+{flipped: -> level23_5}
 * ❯
 -> level23_5
 * [(wait for: flipped)] Flipped!
@@ -65,9 +57,7 @@
 === level23_5 ===
 ~ attractFTH = 1
 - Exactly, Dr. Rowe! That's what the next step is - debug the broken code! Do you see that button on the <b>left side</b> of the screen, {get_user_name()}? That's the <b>Flip to Hack</b> button! You can use it to go behind the scenes and hack the game with the <b>Toolbox</b>. Let's go!
-{ flipped:
-	-> level23_8
-}
+{flipped: -> level23_8}
 * [(wait for: flipped)]  Flipped!
 -> level23_8
 
@@ -78,7 +68,7 @@
 - There's a lock here, but never fear, {get_user_name()}, here's the key! Click the lock to open it, and you'll be able to see the <b>Instructions</b>. They're the code version of the icons you dragged around on the front side of Sidetrack.
 * [(wait for: isLocked is 0)]  Unlocked!
 -> level23_10
-* [(wait for: currentLevel is 24)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 24)] Level {currentLevel-1} Complete!
 -> level24
 
 
@@ -107,33 +97,33 @@
 -> level23_flip
 
 === level23_flip ===
+{not flipped: -> level23_play}
 ~ attractFTH = 1
 - Now <b>flip</b> back to the front of Sidetrack.
 * [(wait for: flipped)]  Flipped back!
 -> level23_play
-* [(wait for: currentLevel is 24)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 24)] Level {currentLevel-1} Complete!
 -> level24
 
 === level23_play ===
 ~ attractFTH = 0
 - Ok, press the <b>Play</b> button!
-* [(wait for: currentLevel is 24)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 24)] Level {currentLevel-1} Complete!
 -> level24
 
 === level24 ===
 ~ attractFTH = 1
 # character: riley
-- Great work! On to the next challenge!
-* ❯
-# character: faber
-- Yikes, looks like this level has 2 errors! Time to <b>flip</b> the app and get to the <b>Instructions</b> again!
+- I've been saving this badge for you, {get_user_name()} - You really know your way around Sidetrack now!
+~ set_game_state("quests.achievements/sidetrack2-complete", true)
+- There are still plenty of challenges ahead, though. Let's keep going, <b>flip</b> the app and hack the <b>Instructions</b> again!
 * [(wait for: flipped)] Flipped!
 -> level24_3
 * [(wait for: currentLevel is 25)] #
 # character: saniel
 - Gibbering heffalumps! That's quite a gambit, {get_user_name()}! I think I might say... how does it go... that "you're the man now, dog!"
 # character: user
-- Level {currentLevel -1} Complete!
+- Level {currentLevel-1} Complete!
 -> level25
 
 
@@ -144,11 +134,12 @@
 -> level24_3_hints
 * [(wait for: codeErrors is 0)] Fixed it!
 -> level24_flip
-* [(wait for: currentLevel is 25)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 25)] Level {currentLevel-1} Complete!
 -> level25
 
 
 === level24_flip ===
+{not flipped: -> level24_play}
 ~ attractFTH = 1
 # character: saniel
 - Good. You've corrected the errors, now <b>flip</b> back to the front of Sidetrack.
@@ -160,7 +151,7 @@
 ~ attractFTH = 0
 # character: estelle
 - Ok, let's give it a shot. Press the <b>Play</b> button! If you don't make it through, you might need different instructions, or a different order of instructions.
-* [(wait for: currentLevel is 25)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 25)] Level {currentLevel-1} Complete!
 -> level25
 
 
@@ -169,7 +160,7 @@
 - Look for <b>Instructions</b> that might be spelled wrong, or that don't make any sense. Remember, if you accidentally create any new errors, you can always Undo your mistakes (<b>Ctrl + Z</b>) or reset the code by clicking the <b>Reload</b> button in the upper right.
 * [Hint] (Hint)
 -> level24_3_hints_2
-* [(wait for: currentLevel is 25)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 25)] Level {currentLevel-1} Complete!
 -> level25
 * [(wait for: codeErrors is 0)] Fixed it!
 -> level24_flip
@@ -180,7 +171,7 @@
 - Do you see where it says <tt>riley.fooorward();</tt>? I don't think that's correct...
 * [Hint] (Hint)
 -> level24_3_hints_final
-* [(wait for: currentLevel is 25)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 25)] Level {currentLevel-1} Complete!
 -> level25
 * [(wait for: codeErrors is 0)] Fixed it!
 -> level24_flip
@@ -189,25 +180,26 @@
 === level24_3_hints_final ===
 # character: faber
 - Oh, hey, I think I see another problem. Look at the capitalization in the code. I think it should be <tt>riley.jump()</tt>, not <tt>riley.<b>J</b>ump()</tt>!
-* [(wait for: currentLevel is 25)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 25)] Level {currentLevel-1} Complete!
 -> level25
 * [(wait for: codeErrors is 0)] Fixed it!
 -> level24_flip
 
 
 === level25 ===
+~ attractFTH = 0
 # character: estelle
 - Riley, did you remember to test your code? We've hit quite a lot of errors!
 * [(wait for: codeErrors is 0)] Fixed it!
 -> level25_fix
-* [(wait for: currentLevel is 26)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 26)] Level {currentLevel-1} Complete!
 -> level26
 
 
 === level25_fix ===
 # character: saniel
 - Well done, you've fixed the errors. Now, <b>flip</b> back and see if you can complete the level. Don't forget that you might still need to re-order or change in instructions to get through.
-* [(wait for: currentLevel is 26)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 26)] Level {currentLevel-1} Complete!
 -> level26
 
 
@@ -216,7 +208,7 @@
 - I don't think these errors are a mistake! Every instruction in this set is wrong, and statistically, that's very unlikely.
 * ❯
 -> level26_2
-* [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 27)] Level {currentLevel-1} Complete!
 -> level26_2
 
 
@@ -225,30 +217,31 @@
 # character: felix
 - <b><i>m*::>^_^<::&rr0w>!</i></b>
 - You said it, Felix! Hey {get_user_name()}, you know the drill now! <b>Flip</b> and hack!
+{not flipped: -> level26_3}
 * [(wait for: flipped)] Flipped!
 -> level26_3
-* [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 27)] Level {currentLevel-1} Complete!
 -> level27
 
 
 === level26_3 ===
 * [(wait for: codeErrors is 0)] Fixed it!
 -> level26_fix
-* [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 27)] Level {currentLevel-1} Complete!
 -> level27
 
 
 === level26_fix ===
 # character: faber
 - Just because you fixed the errors doesn't mean the instructions are correct, you'll probably have to re-order them... or maybe even re-write them completely!
-* [(wait for: currentLevel is 27)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 27)] Level {currentLevel-1} Complete!
 -> level27
 
 
 === level27 ===
 # character: ada
 - It looks like this level has only two incorrect instructions - that's an improvement.
-* [(wait for: currentLevel is 28)] Level {currentLevel -1} Complete!
+* [(wait for: currentLevel is 28)] Level {currentLevel-1} Complete!
 -> level28
 
 
@@ -281,7 +274,6 @@
 
 === level28_5 ===
 # character: saniel
-- Ahem. I think I speak for all of us, here, when I say that we've had a great time with you, {get_user_name()}. Here, take this badge as a reward for your excellent work. I hope we'll see you soon in Endless OS!
+- Ahem. I think I speak for all of us, here, when I say that we've had a great time with you, {get_user_name()}. I hope we'll see you soon in Endless OS!
 ~ set_game_state("quest.Sidetrack2/complete", true)
-~ set_game_state("quests.achievements/sidetrack2-complete", true)
 -> END

--- a/src/ui/quests/sidetrack-quest.ink
+++ b/src/ui/quests/sidetrack-quest.ink
@@ -87,7 +87,6 @@ INCLUDE sidetrack-2-quest.ink
 ~ availableLevels = 28
 // We change the level and wait for the app to update:
 ~ startLevel = 22
--
 + [(wait for: currentLevel is {startLevel})] #
 - -> transition
 

--- a/src/ui/quests/sidetrack-quest.ink
+++ b/src/ui/quests/sidetrack-quest.ink
@@ -69,6 +69,8 @@ INCLUDE sidetrack-2-quest.ink
 }
 
 === begin ===
+// Disable the level selector in Sidetrack:
+~ levelSelectorsEnabled = 0
 -> level1
 
 === level1 ===
@@ -76,8 +78,6 @@ INCLUDE sidetrack-2-quest.ink
 -> end_level_check(2) -> the_choice
 
 === the_choice ===
-// Disable the level selector in Sidetrack:
-~ levelSelectorsEnabled = 0
 - Oh, there's way more than one level here. This is only the beginning!
 - You've got a choice here: Do you want to keep playing normally, or jump straight ahead to hacking the game?
 * [Keep Playing!] I'll keep going, I want to play all the way through.


### PR DESCRIPTION
Addresses both https://phabricator.endlessm.com/T30478 and the very last parts of https://phabricator.endlessm.com/T30359

There were some changes in the initial solution to T30359 that didn't make it in after the decision to disable to level selectors. This restores those changes, normalizes the formatting, and streamlines the quest. Also, this fixes the last remaining issues from T30359, as well as the sync issues in T30478, and the attract issue in T30480.

Flow edits:
- Add easter-egg early completion detection in level 24
- Streamline level 26/27
- Move level selector disable earlier, otherwise it flashes after level 1 is completed
- Remove level22_reorder
- Condense level23 / level23_2 to get the player hacking faster
- Partially addressed T30478 by adding another level-end check
- Add flip detectors to fix the rest of T30478
- Restore badge grant to level 24
- Add a redundant disabling of the FtH attract in level 25, to prevent it from flashing for the rest of the quest (https://phabricator.endlessm.com/T30480)

Text edits:
- Reword some lines to be simpler
- Add lines in 26_2 to make it more clear that the errors are part of the game, not an actual mistake.
- Reword some dialogues to remove characters and streamline nodes

Code formatting:
- Fix code newline spacing (1 after in-level node, 2 between levels)
- Fix spacing after initial "-"
- Fix bad space in ST1 Badge grant and "currentLevel-1"
- Condense flip detectors
- Remove "cont_" from all node names for clearer reading

https://phabricator.endlessm.com/T30478
https://phabricator.endlessm.com/T30359
https://phabricator.endlessm.com/T30480